### PR TITLE
chore: create pr with client generated with latest master to fabric8-cluster-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ CLEAN_TARGETS += clean-generated
 clean-generated:
 	-rm -rf ./app
 	-rm -rf ./client/
+	-rm -rf ./cluster/
 	-rm -rf ./swagger/
 	-rm -rf ./tool
 	-rm -f ./migration/sqlbindata.go

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,10 @@ migrate-database: $(BINARY_SERVER_BIN)
 ## Generate GOA sources. Only necessary after clean of if changed `design` folder.
 generate: app/controllers.go migration/sqlbindata.go configuration/confbindata.go
 
+.PHONY: generate-client
+generate-client: $(GOAGEN_BIN)
+	$(GOAGEN_BIN) client -d github.com/fabric8-services/fabric8-cluster/design --pkg cluster
+
 .PHONY: regenerate
 ## Runs the "clean-generated" and the "generate" target
 regenerate: clean-generated generate

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -4,4 +4,6 @@
 
 cico_setup;
 
+generate_client_setup fabric8-services fabric8-cluster-client;
+
 run_tests_without_coverage;

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -4,6 +4,4 @@
 
 cico_setup;
 
-generate_client_setup fabric8-services fabric8-cluster-client;
-
 run_tests_without_coverage;

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # functions to generate latest client if any change in design pkg
-source <(curl -ssL https://git.io/fxP0E)
+source <(curl -ssL https://git.io/fxD0K)
 
 # Output command before executing
 set -x

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # functions to generate latest client if any change in design pkg
-source <(curl -ssL https://git.io/fxPl2)
+source <(curl -ssL https://git.io/fxP0E)
 
 # Output command before executing
 set -x

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # functions to generate latest client if any change in design pkg
-source <(curl -ssL https://git.io/fxD0K)
+source <(curl -s https://raw.githubusercontent.com/fabric8-services/fabric8-common/master/.scripts/create_push_client.sh)
 
 # Output command before executing
 set -x

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -14,7 +14,7 @@ set -e
 function load_jenkins_vars() {
   if [ -e "jenkins-env" ]; then
     cat jenkins-env \
-      | grep -E "(DEVSHIFT_TAG_LEN|QUAY_USERNAME|QUAY_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
+      | grep -E "(DEVSHIFT_TAG_LEN|QUAY_USERNAME|QUAY_PASSWORD|FABRIC8_HUB_TOKEN|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
       | sed 's/^/export /g' \
       > ~/.jenkins-env
     source ~/.jenkins-env

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# functions to generate latest client if any change in design pkg
+source <(curl -ssL https://git.io/fxPl2)
+
 # Output command before executing
 set -x
 
@@ -133,64 +136,11 @@ function deploy() {
 
   echo 'CICO: Image pushed, ready to update deployed app'
 
-  generate_client_setup
+  generate_client_setup fabric8-services fabric8-cluster-client
 }
 
 function cico_setup() {
   load_jenkins_vars;
   install_deps;
   prepare;
-}
-
-
-function git_configure_and_clone() {
-    git config --global user.name "FABRIC8 CD autobot"
-    git config --global user.email fabric8cd@gmail.com
-
-    set +x
-    echo git clone https://XXXX@github.com/${GHORG}/${GHREPO}.git --depth=1 /tmp/${GHREPO}
-    git clone https://$(echo ${FABRIC8_HUB_TOKEN}|base64 --decode)@github.com/${GHORG}/${GHREPO}.git --depth=1 /tmp/${GHREPO}
-    set -x
-}
-
-function generate_client_and_create_pr() {
-    make generate-client
-
-    local newVersion=$(git rev-parse HEAD)
-    local message="chore: update client version to ${newVersion}"
-    local short_head=$(git rev-parse --short HEAD)
-    local branch="client_update_${short_head}"
-
-    cd /tmp/${GHREPO}
-    git checkout -b ${branch}
-    cd -
-    cp -r cluster tool /tmp/${GHREPO}
-    git rev-parse --short HEAD > /tmp/${GHREPO}/source_commit.txt
-    cd /tmp/${GHREPO}
-
-    git commit cluster tool source_commit.txt -m "${message}"
-    git push -u origin ${branch}
-    rm -rf /tmp/${GHREPO}
-
-    set +x
-    curl -s -X POST -L -H "Authorization: token $(echo ${FABRIC8_HUB_TOKEN}|base64 --decode)" \
-         -d "{\"title\": \"${message}\", \"base\":\"master\", \"head\":\"${branch}\"}" \
-         https://api.github.com/repos/${GHORG}/${GHREPO}/pulls
-    set -x
-}
-
-function generate_client_setup() {
-    set -e
-    SERVICE_NAME=${PWD##*/}
-    GHORG=${GHORG:-fabric8-services}
-    GHREPO=${GHREPO:-${SERVICE_NAME}-client}
-
-    PREV_COMMIT=$(curl -s https://raw.githubusercontent.com/${GHORG}/${GHREPO}/master/source_commit.txt)
-    if [[ $(git diff --reverse $PREV_COMMIT..HEAD design) ]]; then
-        echo "generating new client."
-        git_configure_and_clone
-        generate_client_and_create_pr
-    else
-        echo "no change in design package."
-    fi
 }


### PR DESCRIPTION
**Changes Proposed in this PR**
* Sourcing bash functions to use from `https://git.io/fxP0E`.
* After successful deployment of latest master, we should expect PR to fabric8-cluster-client repo.

Depends on #openshiftio/openshiftio-cico-jobs/pull/861
Depends on #fabric8-services/fabric8-common/pull/36

Note: We are good to merge if this looks good to you and see are we getting new PR to fabric8-cluster-client repo.

Next Steps:
* [ ] Configure CI jobs to client repo to use new client as per PR and check project is building successfully
* [ ] With merge to master, create a PR with the latest client for its consumer.