### PR TITLE
fix: cico deploy execute some target two times

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -2,8 +2,15 @@
 
 . cico_setup.sh
 
-cico_setup;
+load_jenkins_vars
 
-run_tests_without_coverage;
+if [ ! -f .cico-prepare ]; then
+    install_deps
+    prepare
+
+    run_tests_without_coverage;
+
+    touch .cico-prepare
+fi
 
 deploy;


### PR DESCRIPTION
check for f8-cluster logs [link](https://ci.centos.org/view/Devtools/job/devtools-fabric8-cluster-build-master-push-client/2/consoleFull), and search for `make docker-start`, you will find two times .. this PR fix it.

basically cico_build_deploy.sh run twice; one for "rhel" target and other for "non-rhel" target.

