### PR TITLE
fix: add pkg name and tool dir as param

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -136,7 +136,7 @@ function deploy() {
 
   echo 'CICO: Image pushed, ready to update deployed app'
 
-  generate_client_setup fabric8-services fabric8-cluster-client cluster tool/cli
+  generate_client_setup cluster tool/cli fabric8-services fabric8-cluster-client
 }
 
 function cico_setup() {

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -136,7 +136,7 @@ function deploy() {
 
   echo 'CICO: Image pushed, ready to update deployed app'
 
-  generate_client_setup fabric8-services fabric8-cluster-client
+  generate_client_setup fabric8-services fabric8-cluster-client cluster tool/cli
 }
 
 function cico_setup() {

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -136,7 +136,7 @@ function deploy() {
 
   echo 'CICO: Image pushed, ready to update deployed app'
 
-  generate_client_setup cluster tool/cli fabric8-services fabric8-cluster-client
+  generate_client_setup cluster tool fabric8-services fabric8-cluster-client
 }
 
 function cico_setup() {


### PR DESCRIPTION
**Changes proposed in this pr**
* Adds `PKG_NAME` and `TOOL_DIR` as parameters to `cico_setup.sh`

See for Reference https://github.com/fabric8-services/fabric8-common/pull/48/files
