### PR TITLE
fix: move call to generate_client_setup to execute only once during build

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -10,6 +10,8 @@ if [ ! -f .cico-prepare ]; then
 
     run_tests_without_coverage;
 
+    generate_client_setup fabric8-cluster cluster tool fabric8-services fabric8-cluster-client
+
     touch .cico-prepare
 fi
 

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -136,7 +136,6 @@ function deploy() {
 
   echo 'CICO: Image pushed, ready to update deployed app'
 
-  generate_client_setup fabric8-cluster cluster tool fabric8-services fabric8-cluster-client
 }
 
 function cico_setup() {


### PR DESCRIPTION
**Changes Proposed in this PR**
* moves calling to `generate_client_setup` in a setup where it is called only once even if called for different TARGET