### PR TITLE
fix: use epel-testing repository to install golang package

### DIFF
--- a/.make/test.mk
+++ b/.make/test.mk
@@ -147,7 +147,7 @@ test-unit-with-coverage: prebuild-check clean-coverage-unit $(COV_PATH_UNIT)
 test-unit: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_UNIT_TEST=1 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_UNIT_TEST=1 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-unit-junit
 test-unit-junit: prebuild-check ${GO_JUNIT_BIN} ${TMP_PATH}
@@ -164,12 +164,12 @@ test-integration-with-coverage: prebuild-check clean-coverage-integration migrat
 test-integration: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 test-integration-benchmark: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running benchmarks: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_LOG_LEVEL=error F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -run=^$$ -bench=. -cpu 1,2,4 -test.benchmem $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	F8_DEVELOPER_MODE_ENABLED=1 F8_LOG_LEVEL=error F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off -run=^$$ -bench=. -cpu 1,2,4 -test.benchmem $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-remote-with-coverage
 ## Runs the remote tests and produces coverage files for each package.
@@ -180,13 +180,13 @@ test-remote-with-coverage: prebuild-check clean-coverage-remote $(COV_PATH_REMOT
 test-remote: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_REMOTE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_REMOTE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-migration
 ## Runs the migration tests and should be executed before running the integration tests
 ## in order to have a clean database
 test-migration: prebuild-check
-	F8_RESOURCE_DATABASE=1 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_VERBOSITY_FLAG) github.com/fabric8-services/fabric8-cluster/migration
+	F8_RESOURCE_DATABASE=1 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off $(GO_TEST_VERBOSITY_FLAG) github.com/fabric8-services/fabric8-cluster/migration
 
 # Downloads docker-compose to tmp/docker-compose if it does not already exist.
 define download-docker-compose
@@ -425,6 +425,7 @@ $(eval COV_OUT_FILE := $(COV_DIR)/$(PACKAGE_NAME)/coverage.$(TEST_NAME).mode-$(C
 @$(ENV_VAR) F8_DEVELOPER_MODE_ENABLED=1 F8_POSTGRES_HOST=$(F8_POSTGRES_HOST) F8_LOG_LEVEL=$(F8_LOG_LEVEL) \
 	go test $(PACKAGE_NAME) \
 		$(GO_TEST_VERBOSITY_FLAG) \
+		-vet off \
 		-coverprofile $(COV_OUT_FILE) \
 		-coverpkg $(ALL_PKGS_COMMA_SEPARATED) \
 		-covermode=$(COVERAGE_MODE) \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,10 +5,11 @@ ENV LANG=en_US.utf8
 ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 # Some packages might seem weird but they are required by the RVM installer.
-RUN yum --enablerepo=centosplus install -y --quiet \
+RUN yum install epel-release --enablerepo=extras -y \
+    && yum --enablerepo=centosplus --enablerepo=epel-testing install -y \
       findutils \
       git \
-      $(test -z $USE_GO_VERSION_FROM_WEBSITE && echo "golang") \
+      $(test "$USE_GO_VERSION_FROM_WEBSITE" != 1 && echo "golang") \
       make \
       procps-ng \
       tar \
@@ -16,13 +17,13 @@ RUN yum --enablerepo=centosplus install -y --quiet \
       which \
     && yum clean all
 
-RUN test -n $USE_GO_VERSION_FROM_WEBSITE \
-    && cd /tmp \
+RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
     && wget https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
     && echo "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33  go1.10.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
     && tar -C /usr/local -xzf go1.10.linux-amd64.tar.gz \
-    && rm -f go1.10.linux-amd64.tar.gz
+    && rm -f go1.10.linux-amd64.tar.gz; \
+    fi
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Get dep for Go package management and make sure the directory has full rwz permissions for non-root users

--- a/cico_run_coverage.sh
+++ b/cico_run_coverage.sh
@@ -2,7 +2,7 @@
 
 . cico_setup.sh
 
-export USE_GO_VERSION_FROM_WEBSITE=1
+#export USE_GO_VERSION_FROM_WEBSITE=1
 
 cico_setup;
 

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -205,7 +205,7 @@ func TestClusterConfigurationWithGeneratedURLs(t *testing.T) {
 		AuthClientID:                 "autheast2",
 		AuthClientSecret:             "autheast2secret",
 		AuthClientDefaultScope:       "user:full",
-		Type: cluster.OSO,
+		Type:                         cluster.OSO,
 	})
 }
 
@@ -244,8 +244,8 @@ func checkClusterConfiguration(t *testing.T, clusters map[string]configuration.C
 		AuthClientID:                 "autheast2",
 		AuthClientSecret:             "autheast2secret",
 		AuthClientDefaultScope:       "user:full",
-		Type:              "OSO",
-		CapacityExhausted: false,
+		Type:                         "OSO",
+		CapacityExhausted:            false,
 	})
 	checkCluster(t, clusters, configuration.Cluster{
 		Name:                         "us-east-2a",
@@ -261,8 +261,8 @@ func checkClusterConfiguration(t *testing.T, clusters map[string]configuration.C
 		AuthClientID:                 "autheast2a",
 		AuthClientSecret:             "autheast2asecret",
 		AuthClientDefaultScope:       "user:full",
-		Type:              "OSO",
-		CapacityExhausted: false,
+		Type:                         "OSO",
+		CapacityExhausted:            false,
 	})
 	checkCluster(t, clusters, configuration.Cluster{
 		Name:                         "us-east-1a",
@@ -278,8 +278,8 @@ func checkClusterConfiguration(t *testing.T, clusters map[string]configuration.C
 		AuthClientID:                 "autheast1a",
 		AuthClientSecret:             "autheast1asecret",
 		AuthClientDefaultScope:       "user:full",
-		Type:              "OSO",
-		CapacityExhausted: true,
+		Type:                         "OSO",
+		CapacityExhausted:            true,
 	})
 	checkCluster(t, clusters, configuration.Cluster{
 		Name:                         "us-east-3a",
@@ -295,8 +295,8 @@ func checkClusterConfiguration(t *testing.T, clusters map[string]configuration.C
 		AuthClientID:                 "autheast3a",
 		AuthClientSecret:             "autheast3asecret",
 		AuthClientDefaultScope:       "user:full",
-		Type:              "OSD",
-		CapacityExhausted: false,
+		Type:                         "OSD",
+		CapacityExhausted:            false,
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 			"config_file":                 configFile,
 			"service_account_config_file": serviceAccountConfigFile,
 			"cluster_config_file":         clusterConfigFile,
-			"err": err,
+			"err":                         err,
 		}, "failed to setup the configuration")
 	}
 


### PR DESCRIPTION
use `epel-testing` repository to install golang package which was deprecated in CentOS-7
see: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.1810#head-e467ac744557df926ed56dc0106f43961e5ffc38