### PR TITLE
feat: add endpoint to show cluster

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -459,6 +459,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d3c6e8745c479d3ed87af4259ea98b38c8a84795f766a28b0ffd2a87ca181cdd"
+  inputs-digest = "ef23bfbe9d4d9423a1dd2ef86c686d4fe6e4f0b680c5c375b0acf0bd85d5c64a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/fabric8-services/fabric8-cluster/cluster/repository"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 /*
@@ -23,6 +25,7 @@ type ClusterService interface {
 	CreateOrSaveClusterFromConfig(ctx context.Context) error
 	CreateOrSaveCluster(ctx context.Context, clustr *repository.Cluster) error
 	InitializeClusterWatcher() (func() error, error)
+	Load(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
 }
 
 //Services creates instances of service layer objects

--- a/cluster/repository/cluster_repository.go
+++ b/cluster/repository/cluster_repository.go
@@ -161,7 +161,7 @@ func (m *GormClusterRepository) Save(ctx context.Context, c *Cluster) error {
 
 	log.Debug(ctx, map[string]interface{}{
 		"cluster_id": c.ClusterID.String(),
-	}, "Cluster saved!")
+	}, "cluster saved")
 	return nil
 }
 

--- a/cluster/service/cluster_service.go
+++ b/cluster/service/cluster_service.go
@@ -27,6 +27,7 @@ type clusterService struct {
 	loader ConfigLoader
 }
 
+// ConfigLoader to interface for the config watcher/loader
 type ConfigLoader interface {
 	ReloadClusterConfig() error
 	GetClusterConfigurationFilePath() string
@@ -82,6 +83,10 @@ func (c clusterService) CreateOrSaveCluster(ctx context.Context, clustr *reposit
 	return c.ExecuteInTransaction(func() error {
 		return c.Repositories().Clusters().CreateOrSave(ctx, clustr)
 	})
+}
+
+func (c clusterService) Load(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error) {
+	return c.Repositories().Clusters().Load(ctx, clusterID)
 }
 
 const (


### PR DESCRIPTION
2 endpoints, one of them restricted to 'auth'
since it provides more sensitive information
(client ID and secret, SA token and username)

for now, only shows clusters from the DB
also, add a 'location' response header when creating a new cluster

fixes #43

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>