### PR TITLE
feat: read clusters from database

### DIFF
--- a/.make/test.mk
+++ b/.make/test.mk
@@ -147,7 +147,6 @@ test-unit-with-coverage: prebuild-check clean-coverage-unit $(COV_PATH_UNIT)
 test-unit: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	go clean -cache
 	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_UNIT_TEST=1 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-unit-junit
@@ -165,7 +164,6 @@ test-integration-with-coverage: prebuild-check clean-coverage-integration migrat
 test-integration: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	go clean -cache
 	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -p 1 -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 test-integration-benchmark: prebuild-check migrate-database $(SOURCES)

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -147,6 +147,7 @@ test-unit-with-coverage: prebuild-check clean-coverage-unit $(COV_PATH_UNIT)
 test-unit: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
+	go clean -cache
 	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_UNIT_TEST=1 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-unit-junit
@@ -164,12 +165,13 @@ test-integration-with-coverage: prebuild-check clean-coverage-integration migrat
 test-integration: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	go clean -cache
+	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -p 1 -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 test-integration-benchmark: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running benchmarks: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_LOG_LEVEL=error F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -vet off -run=^$$ -bench=. -cpu 1,2,4 -test.benchmem $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	F8_DEVELOPER_MODE_ENABLED=1 F8_LOG_LEVEL=error F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test -p 1 -vet off -run=^$$ -bench=. -cpu 1,2,4 -test.benchmem $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-remote-with-coverage
 ## Runs the remote tests and produces coverage files for each package.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -73,7 +73,7 @@
     "test/auth",
     "test/suite"
   ]
-  revision = "2efd83d29b1e5c657728e83fe03878569c0f122f"
+  revision = "f06e14243602e383835a8f8cbf3675e24a738322"
 
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
@@ -459,6 +459,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ef23bfbe9d4d9423a1dd2ef86c686d4fe6e4f0b680c5c375b0acf0bd85d5c64a"
+  inputs-digest = "a9ab22fa3572b846999de8b025998e2d141d4b629388d031b636f74f158fc6c2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -96,4 +96,4 @@ required = [
 
 [[constraint]]
   name = "github.com/fabric8-services/fabric8-common"
-  revision = "2efd83d29b1e5c657728e83fe03878569c0f122f"
+  revision = "f06e14243602e383835a8f8cbf3675e24a738322"

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -23,7 +23,7 @@ Steps for adding a new Service:
 type ClusterService interface {
 	CreateOrSaveClusterFromConfig(ctx context.Context) error
 	CreateOrSaveCluster(ctx context.Context, clustr *repository.Cluster) error
-	InitializeClusterWatcher() (func() error, chan bool, error)
+	InitializeClusterWatcher() (func() error, error)
 	Load(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
 	LinkIdentityToCluster(ctx context.Context, identityID uuid.UUID, clusterURL string, ignoreError bool) error
 	RemoveIdentityToClusterLink(ctx context.Context, identityID uuid.UUID, clusterURL string) error

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -23,10 +23,11 @@ Steps for adding a new Service:
 type ClusterService interface {
 	CreateOrSaveClusterFromConfig(ctx context.Context) error
 	CreateOrSaveCluster(ctx context.Context, clustr *repository.Cluster) error
-	InitializeClusterWatcher() (func() error, error)
+	InitializeClusterWatcher() (func() error, chan bool, error)
 	Load(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
 	LinkIdentityToCluster(ctx context.Context, identityID uuid.UUID, clusterURL string, ignoreError bool) error
 	RemoveIdentityToClusterLink(ctx context.Context, identityID uuid.UUID, clusterURL string) error
+	List(ctx context.Context) ([]repository.Cluster, error)
 }
 
 //Services creates instances of service layer objects

--- a/cluster/repository/cluster_repository.go
+++ b/cluster/repository/cluster_repository.go
@@ -70,10 +70,11 @@ type ClusterRepository interface {
 	Load(ctx context.Context, ID uuid.UUID) (*Cluster, error)
 	Create(ctx context.Context, u *Cluster) error
 	Save(ctx context.Context, u *Cluster) error
+	CreateOrSave(ctx context.Context, u *Cluster) error
 	Delete(ctx context.Context, ID uuid.UUID) error
 	Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Cluster, error)
 	LoadClusterByURL(ctx context.Context, url string) (*Cluster, error)
-	CreateOrSave(ctx context.Context, u *Cluster) error
+	List(ctx context.Context) ([]Cluster, error)
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name
@@ -188,8 +189,9 @@ func (m *GormClusterRepository) CreateOrSave(ctx context.Context, c *Cluster) er
 		return errs.WithStack(err)
 	}
 
-	log.Debug(ctx, map[string]interface{}{
-		"cluster_id": c.ClusterID.String(),
+	log.Warn(ctx, map[string]interface{}{
+		"cluster_id":   c.ClusterID.String(),
+		"cluster_name": c.Name,
 	}, "Cluster saved!")
 	return nil
 }
@@ -235,4 +237,10 @@ func (m *GormClusterRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Clust
 	}, "cluster query done successfully!")
 
 	return objs, nil
+}
+
+// List list ALL clusters
+func (m *GormClusterRepository) List(ctx context.Context) ([]Cluster, error) {
+	return m.Query()
+
 }

--- a/cluster/repository/cluster_repository.go
+++ b/cluster/repository/cluster_repository.go
@@ -222,7 +222,7 @@ func (m *GormClusterRepository) Delete(ctx context.Context, id uuid.UUID) error 
 	return nil
 }
 
-// Query expose an open ended Query model
+// Query exposes an open ended Query model
 func (m *GormClusterRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Cluster, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "cluster", "query"}, time.Now())
 	var objs []Cluster
@@ -239,7 +239,7 @@ func (m *GormClusterRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Clust
 	return objs, nil
 }
 
-// List list ALL clusters
+// List lists ALL clusters
 func (m *GormClusterRepository) List(ctx context.Context) ([]Cluster, error) {
 	return m.Query()
 

--- a/cluster/repository/cluster_repository.go
+++ b/cluster/repository/cluster_repository.go
@@ -231,10 +231,7 @@ func (m *GormClusterRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Clust
 	if err != nil && err != gorm.ErrRecordNotFound {
 		return nil, errs.WithStack(err)
 	}
-
-	log.Debug(nil, map[string]interface{}{
-		"cluster_list": objs,
-	}, "cluster query done successfully!")
+	log.Debug(nil, map[string]interface{}{}, "cluster query done successfully!")
 
 	return objs, nil
 }

--- a/cluster/repository/cluster_repository_blackbox_test.go
+++ b/cluster/repository/cluster_repository_blackbox_test.go
@@ -209,49 +209,13 @@ func (s *clusterTestSuite) TestQueryOK() {
 
 func (s *clusterTestSuite) TestList() {
 	// given
-	cluster1 := &repository.Cluster{
-		AppDNS:            uuid.NewV4().String(),
-		AuthClientID:      uuid.NewV4().String(),
-		AuthClientSecret:  uuid.NewV4().String(),
-		AuthDefaultScope:  uuid.NewV4().String(),
-		ConsoleURL:        uuid.NewV4().String(),
-		LoggingURL:        uuid.NewV4().String(),
-		MetricsURL:        uuid.NewV4().String(),
-		Name:              uuid.NewV4().String(),
-		SAToken:           uuid.NewV4().String(),
-		SAUsername:        uuid.NewV4().String(),
-		SATokenEncrypted:  true,
-		TokenProviderID:   uuid.NewV4().String(),
-		Type:              "bar",
-		URL:               "http://" + uuid.NewV4().String() + "/",
-		CapacityExhausted: false,
-	}
-	err := s.repo.Create(context.Background(), cluster1)
-	require.NoError(s.T(), err)
-	cluster2 := &repository.Cluster{
-		AppDNS:            uuid.NewV4().String(),
-		AuthClientID:      uuid.NewV4().String(),
-		AuthClientSecret:  uuid.NewV4().String(),
-		AuthDefaultScope:  uuid.NewV4().String(),
-		ConsoleURL:        uuid.NewV4().String(),
-		LoggingURL:        uuid.NewV4().String(),
-		MetricsURL:        uuid.NewV4().String(),
-		Name:              uuid.NewV4().String(),
-		SAToken:           uuid.NewV4().String(),
-		SAUsername:        uuid.NewV4().String(),
-		SATokenEncrypted:  true,
-		TokenProviderID:   uuid.NewV4().String(),
-		Type:              "bar",
-		URL:               "http://" + uuid.NewV4().String() + "/",
-		CapacityExhausted: false,
-	}
-	err = s.repo.Create(context.Background(), cluster2)
-	require.NoError(s.T(), err)
+	cluster1 := test.CreateCluster(s.T(), s.DB)
+	cluster2 := test.CreateCluster(s.T(), s.DB)
 	// when
 	clusters, err := s.repo.List(context.Background())
 	// then
 	require.NoError(s.T(), err)
 	require.Len(s.T(), clusters, 2)
-	test.AssertEqualClusters(s.T(), cluster1, &clusters[0])
-	test.AssertEqualClusters(s.T(), cluster2, &clusters[1])
+	test.AssertClusters(s.T(), clusters, cluster1)
+	test.AssertClusters(s.T(), clusters, cluster2)
 }

--- a/cluster/repository/cluster_repository_blackbox_test.go
+++ b/cluster/repository/cluster_repository_blackbox_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/fabric8-services/fabric8-cluster/cluster/repository"
 	"github.com/fabric8-services/fabric8-cluster/gormtestsupport"
@@ -24,7 +24,7 @@ type clusterTestSuite struct {
 	repo repository.ClusterRepository
 }
 
-func TestCluster(t *testing.T) {
+func TestClusterRepository(t *testing.T) {
 	suite.Run(t, &clusterTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
 }
 
@@ -34,54 +34,59 @@ func (s *clusterTestSuite) SetupTest() {
 }
 
 func (s *clusterTestSuite) TestCreateAndLoadClusterOK() {
+	// given
 	cluster1 := test.CreateCluster(s.T(), s.DB)
 	test.CreateCluster(s.T(), s.DB) // noise
+	// when
 	loaded, err := s.repo.Load(context.Background(), cluster1.ClusterID)
+	// then
 	require.NoError(s.T(), err)
-
 	test.AssertEqualClusters(s.T(), cluster1, loaded)
 }
 
 func (s *clusterTestSuite) TestCreateAndLoadClusterByURLOK() {
+	// given
 	cluster1 := test.CreateCluster(s.T(), s.DB)
 	test.CreateCluster(s.T(), s.DB) // noise
+	// when
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster1.URL)
+	// then
 	require.NoError(s.T(), err)
-
 	test.AssertEqualClusters(s.T(), cluster1, loaded)
 }
 
 func (s *clusterTestSuite) TestCreateAndLoadClusterByURLFail() {
+	// given
 	test.CreateCluster(s.T(), s.DB)
 	test.CreateCluster(s.T(), s.DB) // noise
-
+	// when
 	clusterURL := uuid.NewV4().String()
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), clusterURL)
+	// then
 	assert.Nil(s.T(), loaded)
 	test.AssertError(s.T(), err, errors.NotFoundError{}, fmt.Sprintf("cluster with url %s not found", clusterURL))
 }
 
 func (s *clusterTestSuite) TestCreateOKInCreateOrSave() {
+	// given
 	cluster := test.NewCluster()
 	s.repo.CreateOrSave(context.Background(), cluster)
 	test.CreateCluster(s.T(), s.DB) // noise
-
+	// when
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster.URL)
+	// then
 	require.NoError(s.T(), err)
-
 	test.AssertEqualClusters(s.T(), cluster, loaded)
 }
 
 func (s *clusterTestSuite) TestSaveOKInCreateOrSave() {
+	// given
 	cluster := test.NewCluster()
 	test.CreateCluster(s.T(), s.DB) // noise
 	s.repo.CreateOrSave(context.Background(), cluster)
-
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster.URL)
 	require.NoError(s.T(), err)
-
 	test.AssertEqualClusters(s.T(), cluster, loaded)
-
 	// update cluster details
 	cluster.AppDNS = uuid.NewV4().String()
 	cluster.AuthClientID = uuid.NewV4().String()
@@ -96,44 +101,52 @@ func (s *clusterTestSuite) TestSaveOKInCreateOrSave() {
 	cluster.TokenProviderID = uuid.NewV4().String()
 	cluster.Type = uuid.NewV4().String()
 	cluster.CapacityExhausted = true
-
-	s.repo.CreateOrSave(context.Background(), cluster)
-	loaded, err = s.repo.LoadClusterByURL(context.Background(), cluster.URL)
+	err = s.repo.CreateOrSave(context.Background(), cluster)
 	require.NoError(s.T(), err)
-
+	// when
+	loaded, err = s.repo.LoadClusterByURL(context.Background(), cluster.URL)
+	// then
+	require.NoError(s.T(), err)
 	test.AssertEqualClusters(s.T(), cluster, loaded)
 }
 
 func (s *clusterTestSuite) TestDeleteOK() {
+	// given
 	cluster1 := test.CreateCluster(s.T(), s.DB)
 	cluster2 := test.CreateCluster(s.T(), s.DB) // noise
+	// when
 	err := s.repo.Delete(context.Background(), cluster1.ClusterID)
+	// then
 	require.NoError(s.T(), err)
-
 	_, err = s.repo.Load(context.Background(), cluster1.ClusterID)
 	test.AssertError(s.T(), err, errors.NotFoundError{}, "cluster with id '%s' not found", cluster1.ClusterID)
-
 	loaded, err := s.repo.Load(context.Background(), cluster2.ClusterID)
 	require.NoError(s.T(), err)
 	test.AssertEqualClusters(s.T(), cluster2, loaded)
 }
 
 func (s *clusterTestSuite) TestDeleteUnknownFails() {
+	// given
 	id := uuid.NewV4()
+	// when
 	err := s.repo.Delete(context.Background(), id)
+	// then
 	test.AssertError(s.T(), err, errors.NotFoundError{}, "cluster with id '%s' not found", id)
 }
 
 func (s *clusterTestSuite) TestLoadUnknownFails() {
+	// given
 	id := uuid.NewV4()
+	// when
 	_, err := s.repo.Load(context.Background(), id)
+	// then
 	test.AssertError(s.T(), err, errors.NotFoundError{}, "cluster with id '%s' not found", id)
 }
 
 func (s *clusterTestSuite) TestSaveOK() {
+	// given
 	cluster1 := test.CreateCluster(s.T(), s.DB)
 	cluster2 := test.CreateCluster(s.T(), s.DB) // noise
-
 	cluster1.AppDNS = uuid.NewV4().String()
 	cluster1.AuthClientID = uuid.NewV4().String()
 	cluster1.AuthClientSecret = uuid.NewV4().String()
@@ -148,43 +161,97 @@ func (s *clusterTestSuite) TestSaveOK() {
 	cluster1.Type = uuid.NewV4().String()
 	cluster1.URL = uuid.NewV4().String()
 	cluster1.CapacityExhausted = true
-
+	// when
 	err := s.repo.Save(context.Background(), cluster1)
+	// then
 	require.NoError(s.T(), err)
-
 	loaded1, err := s.repo.Load(context.Background(), cluster1.ClusterID)
 	require.NoError(s.T(), err)
 	test.AssertEqualClusters(s.T(), cluster1, loaded1)
-
 	loaded2, err := s.repo.Load(context.Background(), cluster2.ClusterID)
 	require.NoError(s.T(), err)
 	test.AssertEqualClusters(s.T(), cluster2, loaded2)
 }
 
 func (s *clusterTestSuite) TestSaveUnknownFails() {
+	// given
 	id := uuid.NewV4()
+	// when
 	err := s.repo.Save(context.Background(), &repository.Cluster{ClusterID: id})
+	// then
 	test.AssertError(s.T(), err, errors.NotFoundError{}, "cluster with id '%s' not found", id)
 }
 
 func (s *clusterTestSuite) TestExists() {
+	// given
 	id := uuid.NewV4()
 	err := s.repo.CheckExists(context.Background(), id.String())
 	test.AssertError(s.T(), err, errors.NotFoundError{}, "cluster with id '%s' not found", id)
-
+	// when
 	cluster := test.CreateCluster(s.T(), s.DB)
+	// then
 	err = s.repo.CheckExists(context.Background(), cluster.ClusterID.String())
 	require.NoError(s.T(), err)
 }
 
 func (s *clusterTestSuite) TestQueryOK() {
+	// given
 	cluster1 := test.CreateCluster(s.T(), s.DB)
-
+	// when
 	clusters, err := s.repo.Query(func(db *gorm.DB) *gorm.DB {
 		return db.Where("cluster_id = ?", cluster1.ClusterID)
 	})
-
+	// then
 	require.NoError(s.T(), err)
 	require.Len(s.T(), clusters, 1)
 	test.AssertEqualClusters(s.T(), cluster1, &clusters[0])
+}
+
+func (s *clusterTestSuite) TestList() {
+	// given
+	cluster1 := &repository.Cluster{
+		AppDNS:            uuid.NewV4().String(),
+		AuthClientID:      uuid.NewV4().String(),
+		AuthClientSecret:  uuid.NewV4().String(),
+		AuthDefaultScope:  uuid.NewV4().String(),
+		ConsoleURL:        uuid.NewV4().String(),
+		LoggingURL:        uuid.NewV4().String(),
+		MetricsURL:        uuid.NewV4().String(),
+		Name:              uuid.NewV4().String(),
+		SAToken:           uuid.NewV4().String(),
+		SAUsername:        uuid.NewV4().String(),
+		SATokenEncrypted:  true,
+		TokenProviderID:   uuid.NewV4().String(),
+		Type:              "bar",
+		URL:               "http://" + uuid.NewV4().String() + "/",
+		CapacityExhausted: false,
+	}
+	err := s.repo.Create(context.Background(), cluster1)
+	require.NoError(s.T(), err)
+	cluster2 := &repository.Cluster{
+		AppDNS:            uuid.NewV4().String(),
+		AuthClientID:      uuid.NewV4().String(),
+		AuthClientSecret:  uuid.NewV4().String(),
+		AuthDefaultScope:  uuid.NewV4().String(),
+		ConsoleURL:        uuid.NewV4().String(),
+		LoggingURL:        uuid.NewV4().String(),
+		MetricsURL:        uuid.NewV4().String(),
+		Name:              uuid.NewV4().String(),
+		SAToken:           uuid.NewV4().String(),
+		SAUsername:        uuid.NewV4().String(),
+		SATokenEncrypted:  true,
+		TokenProviderID:   uuid.NewV4().String(),
+		Type:              "bar",
+		URL:               "http://" + uuid.NewV4().String() + "/",
+		CapacityExhausted: false,
+	}
+	err = s.repo.Create(context.Background(), cluster2)
+	require.NoError(s.T(), err)
+	// when
+	clusters, err := s.repo.List(context.Background())
+	// then
+	require.NoError(s.T(), err)
+	require.Len(s.T(), clusters, 2)
+	test.AssertEqualClusters(s.T(), cluster1, &clusters[0])
+	test.AssertEqualClusters(s.T(), cluster2, &clusters[1])
 }

--- a/cluster/repository/cluster_repository_blackbox_test.go
+++ b/cluster/repository/cluster_repository_blackbox_test.go
@@ -41,7 +41,7 @@ func (s *clusterTestSuite) TestCreateAndLoadClusterOK() {
 	loaded, err := s.repo.Load(context.Background(), cluster1.ClusterID)
 	// then
 	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), cluster1, loaded)
+	test.AssertEqualCluster(s.T(), cluster1, loaded)
 }
 
 func (s *clusterTestSuite) TestCreateAndLoadClusterByURLOK() {
@@ -52,7 +52,7 @@ func (s *clusterTestSuite) TestCreateAndLoadClusterByURLOK() {
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster1.URL)
 	// then
 	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), cluster1, loaded)
+	test.AssertEqualCluster(s.T(), cluster1, loaded)
 }
 
 func (s *clusterTestSuite) TestCreateAndLoadClusterByURLFail() {
@@ -76,7 +76,7 @@ func (s *clusterTestSuite) TestCreateOKInCreateOrSave() {
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster.URL)
 	// then
 	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), cluster, loaded)
+	test.AssertEqualCluster(s.T(), cluster, loaded)
 }
 
 func (s *clusterTestSuite) TestSaveOKInCreateOrSave() {
@@ -86,7 +86,7 @@ func (s *clusterTestSuite) TestSaveOKInCreateOrSave() {
 	s.repo.CreateOrSave(context.Background(), cluster)
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster.URL)
 	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), cluster, loaded)
+	test.AssertEqualCluster(s.T(), cluster, loaded)
 	// update cluster details
 	cluster.AppDNS = uuid.NewV4().String()
 	cluster.AuthClientID = uuid.NewV4().String()
@@ -107,7 +107,7 @@ func (s *clusterTestSuite) TestSaveOKInCreateOrSave() {
 	loaded, err = s.repo.LoadClusterByURL(context.Background(), cluster.URL)
 	// then
 	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), cluster, loaded)
+	test.AssertEqualCluster(s.T(), cluster, loaded)
 }
 
 func (s *clusterTestSuite) TestDeleteOK() {
@@ -122,7 +122,7 @@ func (s *clusterTestSuite) TestDeleteOK() {
 	test.AssertError(s.T(), err, errors.NotFoundError{}, "cluster with id '%s' not found", cluster1.ClusterID)
 	loaded, err := s.repo.Load(context.Background(), cluster2.ClusterID)
 	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), cluster2, loaded)
+	test.AssertEqualCluster(s.T(), cluster2, loaded)
 }
 
 func (s *clusterTestSuite) TestDeleteUnknownFails() {
@@ -167,10 +167,10 @@ func (s *clusterTestSuite) TestSaveOK() {
 	require.NoError(s.T(), err)
 	loaded1, err := s.repo.Load(context.Background(), cluster1.ClusterID)
 	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), cluster1, loaded1)
+	test.AssertEqualCluster(s.T(), cluster1, loaded1)
 	loaded2, err := s.repo.Load(context.Background(), cluster2.ClusterID)
 	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), cluster2, loaded2)
+	test.AssertEqualCluster(s.T(), cluster2, loaded2)
 }
 
 func (s *clusterTestSuite) TestSaveUnknownFails() {
@@ -204,7 +204,7 @@ func (s *clusterTestSuite) TestQueryOK() {
 	// then
 	require.NoError(s.T(), err)
 	require.Len(s.T(), clusters, 1)
-	test.AssertEqualClusters(s.T(), cluster1, &clusters[0])
+	test.AssertEqualCluster(s.T(), cluster1, &clusters[0])
 }
 
 func (s *clusterTestSuite) TestList() {

--- a/cluster/repository/identity_cluster.go
+++ b/cluster/repository/identity_cluster.go
@@ -12,7 +12,7 @@ import (
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 type IdentityCluster struct {

--- a/cluster/repository/identity_cluster_blackbox_test.go
+++ b/cluster/repository/identity_cluster_blackbox_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fabric8-services/fabric8-cluster/test"
 	"github.com/fabric8-services/fabric8-common/errors"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/cluster/service/cluster_service.go
+++ b/cluster/service/cluster_service.go
@@ -217,20 +217,13 @@ func ValidateURL(urlStr *string) error {
 
 // InitializeClusterWatcher initializes a file watcher for the cluster config file
 // When the file is updated the configuration synchronously reload the cluster configuration
-func (c clusterService) InitializeClusterWatcher() (func() error, chan bool, error) {
+func (c clusterService) InitializeClusterWatcher() (func() error, error) {
 	watcher, err := fsnotify.NewWatcher()
-	done := make(chan bool)
 	if err != nil {
-		return nil, done, err
+		return nil, err
 	}
 
 	go func() {
-		fmt.Println("config watcher started")
-		defer func() {
-			fmt.Println("config watcher stopped")
-			done <- true // notify external listener that this go routine is done
-			close(done)
-		}()
 		for {
 			select {
 			case event, ok := <-watcher.Events:
@@ -301,7 +294,7 @@ func (c clusterService) InitializeClusterWatcher() (func() error, chan bool, err
 		}, "cluster config file watcher not initialized for non-existent file")
 	}
 
-	return watcher.Close, done, err
+	return watcher.Close, err
 }
 
 // LinkIdentityToCluster links Identity to Cluster

--- a/cluster/service/cluster_service.go
+++ b/cluster/service/cluster_service.go
@@ -70,7 +70,7 @@ func (c clusterService) CreateOrSaveClusterFromConfig(ctx context.Context) error
 			return err
 		}
 	}
-	log.Warn(ctx, map[string]interface{}{}, "done creating/updating clusters from config file")
+	log.Warn(ctx, map[string]interface{}{}, "creating/updating clusters from config file has been completed/done")
 	return nil
 }
 

--- a/cluster/service/cluster_service_blackbox_test.go
+++ b/cluster/service/cluster_service_blackbox_test.go
@@ -459,11 +459,10 @@ func (s *ClusterServiceTestSuite) TestClusterConfigurationWatcher() {
 	// initialize application with new config
 	application := gormapplication.NewGormDB(s.DB, config)
 	// Start watching
-	haltWatcher, done, err := application.ClusterService().InitializeClusterWatcher()
+	haltWatcher, err := application.ClusterService().InitializeClusterWatcher()
 	require.NoError(t, err)
 	defer func() {
 		haltWatcher()
-		<-done // make sure we block until the watcher routine is stopped, so it won't mess up with subsequent tests...
 	}()
 
 	// Update the config file
@@ -492,11 +491,10 @@ func (s *ClusterServiceTestSuite) TestClusterConfigurationWatcher() {
 
 func (s *ClusterServiceTestSuite) TestClusterConfigurationWatcherNoErrorForDefaultConfig() {
 	s.Application = gormapplication.NewGormDB(s.DB, s.Configuration)
-	haltWatcher, done, err := s.Application.ClusterService().InitializeClusterWatcher()
+	haltWatcher, err := s.Application.ClusterService().InitializeClusterWatcher()
 	require.NoError(s.T(), err)
 	defer func() {
 		haltWatcher()
-		<-done // make sure we block until the watcher routine is stopped, so it won't mess up with subsequent tests...
 	}()
 }
 

--- a/cluster/service/cluster_service_blackbox_test.go
+++ b/cluster/service/cluster_service_blackbox_test.go
@@ -408,7 +408,7 @@ func (s *ClusterServiceTestSuite) TestLoad() {
 		// then
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		test.AssertEqualClusters(t, c, result)
+		test.AssertEqualCluster(t, c, result)
 	})
 
 	s.T().Run("not found", func(t *testing.T) {
@@ -516,14 +516,14 @@ func (s *ClusterServiceTestSuite) TestLinkIdentityToCluster() {
 			// then
 			loaded1, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c1.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualClusters(t, c1, &loaded1.Cluster)
+			test.AssertEqualCluster(t, c1, &loaded1.Cluster)
 			test.AssertEqualIdentityClusters(t, identityCluster1, loaded1)
 
 			clusters, err := s.Application.IdentityClusters().ListClustersForIdentity(s.Ctx, identityID)
 			require.NoError(t, err)
 
 			assert.Len(t, clusters, 1)
-			test.AssertEqualClusters(t, c1, &clusters[0])
+			test.AssertEqualCluster(t, c1, &clusters[0])
 		})
 
 		t.Run("do not ignore if exists", func(t *testing.T) {
@@ -540,14 +540,14 @@ func (s *ClusterServiceTestSuite) TestLinkIdentityToCluster() {
 			// then
 			loaded1, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c1.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualClusters(t, c1, &loaded1.Cluster)
+			test.AssertEqualCluster(t, c1, &loaded1.Cluster)
 			test.AssertEqualIdentityClusters(t, identityCluster1, loaded1)
 
 			clusters, err := s.Application.IdentityClusters().ListClustersForIdentity(s.Ctx, identityID)
 			require.NoError(t, err)
 
 			assert.Len(t, clusters, 1)
-			test.AssertEqualClusters(t, c1, &clusters[0])
+			test.AssertEqualCluster(t, c1, &clusters[0])
 		})
 
 		t.Run("link multiple clusters to single identity", func(t *testing.T) {
@@ -570,12 +570,12 @@ func (s *ClusterServiceTestSuite) TestLinkIdentityToCluster() {
 			// then
 			loaded1, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c1.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualClusters(t, c1, &loaded1.Cluster)
+			test.AssertEqualCluster(t, c1, &loaded1.Cluster)
 			test.AssertEqualIdentityClusters(t, identityCluster1, loaded1)
 
 			loaded2, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c2.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualClusters(t, c2, &loaded2.Cluster)
+			test.AssertEqualCluster(t, c2, &loaded2.Cluster)
 			test.AssertEqualIdentityClusters(t, identityCluster2, loaded2)
 		})
 	})
@@ -633,11 +633,11 @@ func (s *ClusterServiceTestSuite) TestRemoveIdentityToClusterLink() {
 			clusters, err := s.Application.IdentityClusters().ListClustersForIdentity(s.Ctx, identityID)
 			require.NoError(t, err)
 			require.Len(t, clusters, 1)
-			test.AssertEqualClusters(t, c1, &clusters[0])
+			test.AssertEqualCluster(t, c1, &clusters[0])
 
 			loaded1, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c1.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualClusters(t, c1, &loaded1.Cluster)
+			test.AssertEqualCluster(t, c1, &loaded1.Cluster)
 			test.AssertEqualIdentityClusters(t, identityCluster1, loaded1)
 
 			_, err = s.Application.IdentityClusters().Load(s.Ctx, identityID, c2.ClusterID)
@@ -664,22 +664,12 @@ func (s *ClusterServiceTestSuite) TestList() {
 	err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
 	require.NoError(s.T(), err)
 	// when
-	clusters, err := s.Application.ClusterService().List(context.Background())
+	result, err := s.Application.ClusterService().List(context.Background())
 	// then
 	require.NoError(s.T(), err)
-	require.Len(s.T(), clusters, 4)
-	// collect cluster URLs and compare with expectations
-	clusterURLs := make([]string, len(clusters))
-	for i, c := range clusters {
-		clusterURLs[i] = c.URL
-	}
-	// see configuration/conf-files/oso-clusters.conf
-	assert.ElementsMatch(s.T(), []string{
-		"https://api.starter-us-east-3a.openshift.com/",
-		"https://api.starter-us-east-2.openshift.com/",
-		"https://api.starter-us-east-2a.openshift.com/",
-		"https://api.starter-us-east-1a.openshift.com/"},
-		clusterURLs)
+	expected, err := repository.NewClusterRepository(s.DB).List(context.Background())
+	require.NoError(s.T(), err)
+	test.AssertEqualClusters(s.T(), expected, result)
 }
 
 func createTempClusterConfigFile(t *testing.T) string {

--- a/controller/clusters.go
+++ b/controller/clusters.go
@@ -41,16 +41,16 @@ func (c *ClustersController) List(ctx *app.ListClustersContext) error {
 		return app.JSONErrorResponse(ctx, err)
 	}
 	var data []*app.ClusterData
-	for _, configCluster := range clusters {
+	for _, c := range clusters {
 		clusterData := &app.ClusterData{
-			Name:              configCluster.Name,
-			APIURL:            httpsupport.AddTrailingSlashToURL(configCluster.URL),
-			ConsoleURL:        httpsupport.AddTrailingSlashToURL(configCluster.ConsoleURL),
-			MetricsURL:        httpsupport.AddTrailingSlashToURL(configCluster.MetricsURL),
-			LoggingURL:        httpsupport.AddTrailingSlashToURL(configCluster.LoggingURL),
-			AppDNS:            configCluster.AppDNS,
-			Type:              configCluster.Type,
-			CapacityExhausted: configCluster.CapacityExhausted,
+			Name:              c.Name,
+			APIURL:            httpsupport.AddTrailingSlashToURL(c.URL),
+			ConsoleURL:        httpsupport.AddTrailingSlashToURL(c.ConsoleURL),
+			MetricsURL:        httpsupport.AddTrailingSlashToURL(c.MetricsURL),
+			LoggingURL:        httpsupport.AddTrailingSlashToURL(c.LoggingURL),
+			AppDNS:            c.AppDNS,
+			Type:              c.Type,
+			CapacityExhausted: c.CapacityExhausted,
 		}
 		data = append(data, clusterData)
 	}
@@ -71,24 +71,26 @@ func (c *ClustersController) ListForAuthClient(ctx *app.ListForAuthClientCluster
 		return app.JSONErrorResponse(ctx, err)
 	}
 	var data []*app.FullClusterData
-	for _, configCluster := range clusters {
-		cluster := &app.FullClusterData{
-			Name:                   configCluster.Name,
-			APIURL:                 httpsupport.AddTrailingSlashToURL(configCluster.URL),
-			ConsoleURL:             httpsupport.AddTrailingSlashToURL(configCluster.ConsoleURL),
-			MetricsURL:             httpsupport.AddTrailingSlashToURL(configCluster.MetricsURL),
-			LoggingURL:             httpsupport.AddTrailingSlashToURL(configCluster.LoggingURL),
-			AppDNS:                 configCluster.AppDNS,
-			Type:                   configCluster.Type,
-			CapacityExhausted:      configCluster.CapacityExhausted,
-			AuthClientDefaultScope: configCluster.AuthDefaultScope,
-			AuthClientID:           configCluster.AuthClientID,
-			AuthClientSecret:       configCluster.AuthClientSecret,
-			ServiceAccountToken:    configCluster.SAToken,
-			ServiceAccountUsername: configCluster.SAUsername,
-			TokenProviderID:        configCluster.TokenProviderID,
+	for _, c := range clusters {
+		encrypted := c.SATokenEncrypted
+		clusterData := &app.FullClusterData{
+			Name:                   c.Name,
+			APIURL:                 httpsupport.AddTrailingSlashToURL(c.URL),
+			ConsoleURL:             httpsupport.AddTrailingSlashToURL(c.ConsoleURL),
+			MetricsURL:             httpsupport.AddTrailingSlashToURL(c.MetricsURL),
+			LoggingURL:             httpsupport.AddTrailingSlashToURL(c.LoggingURL),
+			AppDNS:                 c.AppDNS,
+			Type:                   c.Type,
+			CapacityExhausted:      c.CapacityExhausted,
+			AuthClientDefaultScope: c.AuthDefaultScope,
+			AuthClientID:           c.AuthClientID,
+			AuthClientSecret:       c.AuthClientSecret,
+			SaTokenEncrypted:       &encrypted,
+			ServiceAccountToken:    c.SAToken,
+			ServiceAccountUsername: c.SAUsername,
+			TokenProviderID:        c.TokenProviderID,
 		}
-		data = append(data, cluster)
+		data = append(data, clusterData)
 	}
 	return ctx.OK(&app.FullClusterList{
 		Data: data,
@@ -145,6 +147,7 @@ func (c *ClustersController) ShowForAuthClient(ctx *app.ShowForAuthClientCluster
 			AuthClientSecret:       clustr.AuthClientSecret,
 			ServiceAccountToken:    clustr.SAToken,
 			ServiceAccountUsername: clustr.SAUsername,
+			SaTokenEncrypted:       &clustr.SATokenEncrypted,
 			TokenProviderID:        clustr.TokenProviderID,
 		},
 	})

--- a/controller/clusters_blackbox_test.go
+++ b/controller/clusters_blackbox_test.go
@@ -1,6 +1,7 @@
 package controller_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -20,116 +21,276 @@ import (
 	authtestsupport "github.com/fabric8-services/fabric8-common/test/auth"
 
 	"github.com/goadesign/goa"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-type ClusterControllerTestSuite struct {
+type ClustersControllerTestSuite struct {
 	gormtestsupport.DBTestSuite
 }
 
-func TestClusterController(t *testing.T) {
-	suite.Run(t, &ClusterControllerTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+func TestClustersController(t *testing.T) {
+	suite.Run(t, &ClustersControllerTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
 }
 
-func (s *ClusterControllerTestSuite) newSecuredControllerWithServiceAccount(serviceAccount *authtestsupport.Identity) (*goa.Service, *controller.ClustersController) {
+func (s *ClustersControllerTestSuite) SetupSuite() {
+	s.DBTestSuite.SetupSuite()
+	// save clusters from config in DB
+	err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
+	require.NoError(s.T(), err)
+}
+
+func (s *ClustersControllerTestSuite) newSecuredControllerWithServiceAccount(serviceAccount *authtestsupport.Identity) (*goa.Service, *controller.ClustersController) {
 	svc, err := authtestsupport.ServiceAsServiceAccountUser("Token-Service", serviceAccount)
 	require.NoError(s.T(), err)
-	return svc, NewClustersController(svc, s.Configuration, s.Application)
+	return svc, NewClustersController(svc, s.Application)
 }
 
-func (s *ClusterControllerTestSuite) TestShowForServiceAccountsOK() {
-	require.True(s.T(), len(s.Configuration.GetClusters()) > 0)
-	s.checkShowForServiceAccount("fabric8-oso-proxy")
-	s.checkShowForServiceAccount("fabric8-tenant")
-	s.checkShowForServiceAccount("fabric8-jenkins-idler")
-	s.checkShowForServiceAccount("fabric8-jenkins-proxy")
-	s.checkShowForServiceAccount("fabric8-auth")
-}
+func (s *ClustersControllerTestSuite) TestShow() {
 
-func (s *ClusterControllerTestSuite) checkShowForServiceAccount(saName string) {
+	// given
 	sa := &authtestsupport.Identity{
-		Username: saName,
+		Username: authsupport.ToolChainOperator,
 		ID:       uuid.NewV4(),
 	}
+	clusterPayload := newCreateClusterPayload()
 	svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-	_, clusters := test.ListClustersOK(s.T(), svc.Context, svc, ctrl)
-	require.NotNil(s.T(), clusters)
-	require.NotNil(s.T(), clusters.Data)
-	require.Equal(s.T(), len(s.Configuration.GetClusters()), len(clusters.Data))
-	for _, cluster := range clusters.Data {
-		configCluster := s.Configuration.GetClusterByURL(cluster.APIURL)
-		require.NotNil(s.T(), configCluster)
-		assert.Equal(s.T(), configCluster.Name, cluster.Name)
-		assert.Equal(s.T(), httpsupport.AddTrailingSlashToURL(configCluster.APIURL), cluster.APIURL)
-		assert.Equal(s.T(), httpsupport.AddTrailingSlashToURL(configCluster.ConsoleURL), cluster.ConsoleURL)
-		assert.Equal(s.T(), httpsupport.AddTrailingSlashToURL(configCluster.MetricsURL), cluster.MetricsURL)
-		assert.Equal(s.T(), httpsupport.AddTrailingSlashToURL(configCluster.LoggingURL), cluster.LoggingURL)
-		assert.Equal(s.T(), configCluster.AppDNS, cluster.AppDNS)
-		assert.Equal(s.T(), configCluster.Type, cluster.Type)
-		assert.Equal(s.T(), configCluster.CapacityExhausted, cluster.CapacityExhausted)
-	}
-}
+	resp := test.CreateClustersCreated(s.T(), svc.Context, svc, ctrl, &clusterPayload)
+	location := resp.Header().Get("location")
+	require.NotEmpty(s.T(), location)
+	splits := strings.Split(location, "/")
+	clusterID, err := uuid.FromString(splits[len(splits)-1])
+	require.NoError(s.T(), err)
 
-func (s *ClusterControllerTestSuite) TestShowForUnknownSAFails() {
+	s.T().Run("ok", func(t *testing.T) {
+		for _, saName := range []string{"fabric8-oso-proxy", "fabric8-tenant", "fabric8-jenkins-idler", "fabric8-jenkins-proxy", "fabric8-auth"} {
+			t.Run(saName, func(t *testing.T) {
+				// when accessing the created cluster with another identity
+				sa = &authtestsupport.Identity{
+					Username: saName,
+					ID:       uuid.NewV4(),
+				}
+				svc, ctrl = s.newSecuredControllerWithServiceAccount(sa)
+				_, result := test.ShowClustersOK(t, svc.Context, svc, ctrl, clusterID)
+				// then
+				require.NotNil(t, result)
+				require.NotNil(t, result.Data)
+				assert.Equal(t, clusterPayload.Data.Name, result.Data.Name)
+				name := result.Data.Name
+				assert.Equal(t, httpsupport.AddTrailingSlashToURL(clusterPayload.Data.APIURL), result.Data.APIURL)
+				assert.Equal(t, httpsupport.AddTrailingSlashToURL(clusterPayload.Data.AppDNS), result.Data.AppDNS)
+				assert.Equal(t, false, result.Data.CapacityExhausted)
+				assert.Equal(t, fmt.Sprintf("https://console.cluster.%s/console/", name), result.Data.ConsoleURL)
+				assert.Equal(t, fmt.Sprintf("https://metrics.cluster.%s/", name), result.Data.MetricsURL)
+				assert.Equal(t, fmt.Sprintf("https://console.cluster.%s/console/", name), result.Data.LoggingURL)
+				assert.Equal(t, clusterPayload.Data.Type, result.Data.Type)
+			})
+		}
+	})
+
+	s.T().Run("failure", func(t *testing.T) {
+
+		t.Run("not found", func(t *testing.T) {
+			// given
+			sa := &authtestsupport.Identity{
+				Username: authsupport.Auth,
+				ID:       uuid.NewV4(),
+			}
+			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+			// when/then
+			test.ShowClustersNotFound(t, svc.Context, svc, ctrl, uuid.NewV4())
+		})
+
+		t.Run("not allowed", func(t *testing.T) {
+			// given
+			sa := &authtestsupport.Identity{
+				Username: "foo",
+				ID:       uuid.NewV4(),
+			}
+			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+			// when/then
+			test.ShowClustersUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4())
+		})
+	})
+
+}
+func (s *ClustersControllerTestSuite) TestShowForAuthClient() {
+
+	// given
 	sa := &authtestsupport.Identity{
-		Username: "unknown-sa",
+		Username: authsupport.ToolChainOperator,
 		ID:       uuid.NewV4(),
 	}
+	clusterPayload := newCreateClusterPayload()
 	svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-	test.ListClustersUnauthorized(s.T(), svc.Context, svc, ctrl)
+	resp := test.CreateClustersCreated(s.T(), svc.Context, svc, ctrl, &clusterPayload)
+	location := resp.Header().Get("location")
+	require.NotEmpty(s.T(), location)
+	splits := strings.Split(location, "/")
+	clusterID, err := uuid.FromString(splits[len(splits)-1])
+	require.NoError(s.T(), err)
+
+	s.T().Run("ok", func(t *testing.T) {
+		// when accessing the created cluster with another identity
+		sa = &authtestsupport.Identity{
+			Username: authsupport.Auth,
+			ID:       uuid.NewV4(),
+		}
+		svc, ctrl = s.newSecuredControllerWithServiceAccount(sa)
+		_, result := test.ShowForAuthClientClustersOK(t, svc.Context, svc, ctrl, clusterID)
+		// then
+		require.NotNil(t, result)
+		require.NotNil(t, result.Data)
+		assert.Equal(t, clusterPayload.Data.Name, result.Data.Name)
+		name := result.Data.Name
+		assert.Equal(t, httpsupport.AddTrailingSlashToURL(clusterPayload.Data.APIURL), result.Data.APIURL)
+		assert.Equal(t, httpsupport.AddTrailingSlashToURL(clusterPayload.Data.AppDNS), result.Data.AppDNS)
+		assert.Equal(t, false, result.Data.CapacityExhausted)
+		assert.Equal(t, fmt.Sprintf("https://console.cluster.%s/console/", name), result.Data.ConsoleURL)
+		assert.Equal(t, fmt.Sprintf("https://metrics.cluster.%s/", name), result.Data.MetricsURL)
+		assert.Equal(t, fmt.Sprintf("https://console.cluster.%s/console/", name), result.Data.LoggingURL)
+		assert.Equal(t, clusterPayload.Data.Type, result.Data.Type)
+		assert.Equal(t, clusterPayload.Data.AuthClientDefaultScope, result.Data.AuthClientDefaultScope)
+		assert.Equal(t, clusterPayload.Data.AuthClientID, result.Data.AuthClientID)
+		assert.Equal(t, clusterPayload.Data.AuthClientSecret, result.Data.AuthClientSecret)
+		assert.Equal(t, clusterPayload.Data.ServiceAccountToken, result.Data.ServiceAccountToken)
+		assert.Equal(t, clusterPayload.Data.ServiceAccountUsername, result.Data.ServiceAccountUsername)
+	})
+
+	s.T().Run("failure", func(t *testing.T) {
+
+		t.Run("not found", func(t *testing.T) {
+			// given
+			sa := &authtestsupport.Identity{
+				Username: authsupport.Auth,
+				ID:       uuid.NewV4(),
+			}
+			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+			// when/then
+			test.ShowForAuthClientClustersNotFound(t, svc.Context, svc, ctrl, uuid.NewV4())
+		})
+
+		t.Run("not allowed", func(t *testing.T) {
+			// given
+			sa := &authtestsupport.Identity{
+				Username: auth.Tenant,
+				ID:       uuid.NewV4(),
+			}
+			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+			// when/then
+			test.ShowForAuthClientClustersUnauthorized(t, svc.Context, svc, ctrl, clusterID)
+		})
+	})
+
 }
 
-func (s *ClusterControllerTestSuite) TestShowForAuthServiceAccountsOK() {
+func (s *ClustersControllerTestSuite) TestList() {
 	require.NotEmpty(s.T(), s.Configuration.GetClusters())
-	s.checkShowAuthForServiceAccount("fabric8-auth")
+
+	s.T().Run("ok", func(t *testing.T) {
+		for _, saName := range []string{"fabric8-oso-proxy", "fabric8-tenant", "fabric8-jenkins-idler", "fabric8-jenkins-proxy", "fabric8-auth"} {
+			t.Run(saName, func(t *testing.T) {
+				// given
+				sa := &authtestsupport.Identity{
+					Username: saName,
+					ID:       uuid.NewV4(),
+				}
+				svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+				// when
+				_, clusters := test.ListClustersOK(t, svc.Context, svc, ctrl)
+				// then
+				require.NotNil(t, clusters)
+				require.NotNil(t, clusters.Data)
+				require.Len(t, clusters.Data, len(s.Configuration.GetClusters()))
+				for _, cluster := range clusters.Data {
+					t.Logf("checking cluster '%s' (%s)", cluster.Name, cluster.APIURL)
+					configCluster := s.Configuration.GetClusterByURL(cluster.APIURL)
+					require.NotNil(t, configCluster)
+					assert.Equal(t, configCluster.Name, cluster.Name)
+					assert.Equal(t, httpsupport.AddTrailingSlashToURL(configCluster.APIURL), cluster.APIURL)
+					assert.Equal(t, httpsupport.AddTrailingSlashToURL(configCluster.ConsoleURL), cluster.ConsoleURL)
+					assert.Equal(t, httpsupport.AddTrailingSlashToURL(configCluster.MetricsURL), cluster.MetricsURL)
+					assert.Equal(t, httpsupport.AddTrailingSlashToURL(configCluster.LoggingURL), cluster.LoggingURL)
+					assert.Equal(t, configCluster.AppDNS, cluster.AppDNS)
+					assert.Equal(t, configCluster.Type, cluster.Type)
+					assert.Equal(t, configCluster.CapacityExhausted, cluster.CapacityExhausted)
+				}
+			})
+		}
+	})
+
+	s.T().Run("failures", func(t *testing.T) {
+
+		t.Run("unauthorized", func(t *testing.T) {
+			// given
+			sa := &authtestsupport.Identity{
+				Username: "unknown-sa",
+				ID:       uuid.NewV4(),
+			}
+			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+			// when/then
+			test.ListClustersUnauthorized(s.T(), svc.Context, svc, ctrl)
+		})
+
+	})
 }
 
-func (s *ClusterControllerTestSuite) TestShowAuthForUnknownSAFails() {
-	sa := &authtestsupport.Identity{
-		Username: "fabric8-tenant",
-		ID:       uuid.NewV4(),
-	}
-	svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-	test.ListForAuthClientClustersUnauthorized(s.T(), svc.Context, svc, ctrl)
+func (s *ClustersControllerTestSuite) TestListForAuth() {
+	// given
+	require.NotEmpty(s.T(), s.Configuration.GetClusters())
+
+	s.T().Run("authorized", func(t *testing.T) {
+
+		t.Run("fabric8-auth", func(t *testing.T) {
+			sa := &authtestsupport.Identity{
+				Username: "fabric8-auth",
+				ID:       uuid.NewV4(),
+			}
+			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+			_, clusters := test.ListForAuthClientClustersOK(t, svc.Context, svc, ctrl)
+			require.NotNil(t, clusters)
+			require.NotNil(t, clusters.Data)
+			require.Equal(t, len(s.Configuration.GetClusters()), len(clusters.Data))
+			for _, cluster := range clusters.Data {
+				t.Logf("checking cluster '%s' (%s)", cluster.Name, cluster.APIURL)
+				configCluster := s.Configuration.GetClusterByURL(cluster.APIURL)
+				require.NotNil(t, configCluster)
+				assert.Equal(t, configCluster.Name, cluster.Name)
+				assert.Equal(t, httpsupport.AddTrailingSlashToURL(configCluster.APIURL), cluster.APIURL)
+				assert.Equal(t, httpsupport.AddTrailingSlashToURL(configCluster.ConsoleURL), cluster.ConsoleURL)
+				assert.Equal(t, httpsupport.AddTrailingSlashToURL(configCluster.MetricsURL), cluster.MetricsURL)
+				assert.Equal(t, httpsupport.AddTrailingSlashToURL(configCluster.LoggingURL), cluster.LoggingURL)
+				assert.Equal(t, configCluster.AppDNS, cluster.AppDNS)
+				assert.Equal(t, configCluster.Type, cluster.Type)
+				assert.Equal(t, configCluster.CapacityExhausted, cluster.CapacityExhausted)
+				assert.Equal(t, configCluster.AuthClientDefaultScope, cluster.AuthClientDefaultScope)
+				assert.Equal(t, configCluster.AuthClientID, cluster.AuthClientID)
+				assert.Equal(t, configCluster.AuthClientSecret, cluster.AuthClientSecret)
+				assert.Equal(t, configCluster.ServiceAccountToken, cluster.ServiceAccountToken)
+				assert.Equal(t, configCluster.ServiceAccountUsername, cluster.ServiceAccountUsername)
+				assert.Equal(t, configCluster.TokenProviderID, cluster.TokenProviderID)
+			}
+		})
+	})
+
+	s.T().Run("unauthorized", func(t *testing.T) {
+		t.Run("fabric8-tenant", func(t *testing.T) {
+			sa := &authtestsupport.Identity{
+				Username: "fabric8-tenant",
+				ID:       uuid.NewV4(),
+			}
+			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+			test.ListForAuthClientClustersUnauthorized(s.T(), svc.Context, svc, ctrl)
+		})
+	})
 }
 
 func createLinkIdentityClusterPayload(clusterURL, identityID string, ignoreIfExists *bool) *app.LinkIdentityToClusterData {
 	return &app.LinkIdentityToClusterData{ClusterURL: clusterURL, IdentityID: identityID, IgnoreIfAlreadyExists: ignoreIfExists}
 }
 
-func (s *ClusterControllerTestSuite) checkShowAuthForServiceAccount(saName string) {
-	sa := &authtestsupport.Identity{
-		Username: saName,
-		ID:       uuid.NewV4(),
-	}
-	svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-	_, clusters := test.ListForAuthClientClustersOK(s.T(), svc.Context, svc, ctrl)
-	require.NotNil(s.T(), clusters)
-	require.NotNil(s.T(), clusters.Data)
-	require.Equal(s.T(), len(s.Configuration.GetClusters()), len(clusters.Data))
-	for _, cluster := range clusters.Data {
-		configCluster := s.Configuration.GetClusterByURL(cluster.APIURL)
-		require.NotNil(s.T(), configCluster)
-		assert.Equal(s.T(), configCluster.Name, cluster.Name)
-		assert.Equal(s.T(), httpsupport.AddTrailingSlashToURL(configCluster.APIURL), cluster.APIURL)
-		assert.Equal(s.T(), httpsupport.AddTrailingSlashToURL(configCluster.ConsoleURL), cluster.ConsoleURL)
-		assert.Equal(s.T(), httpsupport.AddTrailingSlashToURL(configCluster.MetricsURL), cluster.MetricsURL)
-		assert.Equal(s.T(), httpsupport.AddTrailingSlashToURL(configCluster.LoggingURL), cluster.LoggingURL)
-		assert.Equal(s.T(), configCluster.AppDNS, cluster.AppDNS)
-		assert.Equal(s.T(), configCluster.Type, cluster.Type)
-		assert.Equal(s.T(), configCluster.CapacityExhausted, cluster.CapacityExhausted)
-		assert.Equal(s.T(), configCluster.AuthClientDefaultScope, cluster.AuthClientDefaultScope)
-		assert.Equal(s.T(), configCluster.AuthClientID, cluster.AuthClientID)
-		assert.Equal(s.T(), configCluster.AuthClientSecret, cluster.AuthClientSecret)
-		assert.Equal(s.T(), configCluster.ServiceAccountToken, cluster.ServiceAccountToken)
-		assert.Equal(s.T(), configCluster.ServiceAccountUsername, cluster.ServiceAccountUsername)
-		assert.Equal(s.T(), configCluster.TokenProviderID, cluster.TokenProviderID)
-	}
-}
-
-func (s *ClusterControllerTestSuite) TestCreate() {
+func (s *ClustersControllerTestSuite) TestCreate() {
 
 	s.T().Run("ok", func(t *testing.T) {
 		// given
@@ -175,7 +336,7 @@ func (s *ClusterControllerTestSuite) TestCreate() {
 	})
 }
 
-func (s *ClusterControllerTestSuite) TestLinkIdentityClusters() {
+func (s *ClustersControllerTestSuite) TestLinkIdentityClusters() {
 
 	s.T().Run("ok", func(t *testing.T) {
 		t.Run("ignore if exists - nil", func(t *testing.T) {
@@ -316,7 +477,7 @@ func (s *ClusterControllerTestSuite) TestLinkIdentityClusters() {
 	})
 }
 
-func (s *ClusterControllerTestSuite) TestRemoveIdentityToClustersLink() {
+func (s *ClustersControllerTestSuite) TestRemoveIdentityToClustersLink() {
 
 	s.T().Run("ok", func(t *testing.T) {
 		t.Run("unlink", func(t *testing.T) {
@@ -448,137 +609,4 @@ func newCreateClusterPayload() app.CreateClustersPayload {
 			Type:                   "OSD",
 		},
 	}
-}
-
-func (s *ClusterControllerTestSuite) TestShow() {
-
-	s.T().Run("ok", func(t *testing.T) {
-		// given
-		sa := &authtestsupport.Identity{
-			Username: authsupport.ToolChainOperator,
-			ID:       uuid.NewV4(),
-		}
-		clusterPayload := newCreateClusterPayload()
-		svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-		resp := test.CreateClustersCreated(t, svc.Context, svc, ctrl, &clusterPayload)
-		location := resp.Header().Get("location")
-		require.NotEmpty(t, location)
-		// when accessing the created cluster with another identity
-		sa = &authtestsupport.Identity{
-			Username: authsupport.Auth,
-			ID:       uuid.NewV4(),
-		}
-		svc, ctrl = s.newSecuredControllerWithServiceAccount(sa)
-		splits := strings.Split(location, "/")
-		clusterID, err := uuid.FromString(splits[len(splits)-1])
-		require.NoError(t, err)
-		_, result := test.ShowClustersOK(t, svc.Context, svc, ctrl, clusterID)
-		// then
-		require.NotNil(t, result)
-		require.NotNil(t, result.Data)
-		assert.Equal(t, clusterPayload.Data.Name, result.Data.Name)
-		name := result.Data.Name
-		assert.Equal(t, httpsupport.AddTrailingSlashToURL(clusterPayload.Data.APIURL), result.Data.APIURL)
-		assert.Equal(t, httpsupport.AddTrailingSlashToURL(clusterPayload.Data.AppDNS), result.Data.AppDNS)
-		assert.Equal(t, false, result.Data.CapacityExhausted)
-		assert.Equal(t, fmt.Sprintf("https://console.cluster.%s/console/", name), result.Data.ConsoleURL)
-		assert.Equal(t, fmt.Sprintf("https://metrics.cluster.%s/", name), result.Data.MetricsURL)
-		assert.Equal(t, fmt.Sprintf("https://console.cluster.%s/console/", name), result.Data.LoggingURL)
-		assert.Equal(t, clusterPayload.Data.Type, result.Data.Type)
-
-	})
-
-	s.T().Run("failure", func(t *testing.T) {
-
-		t.Run("not found", func(t *testing.T) {
-			// given
-			sa := &authtestsupport.Identity{
-				Username: authsupport.Auth,
-				ID:       uuid.NewV4(),
-			}
-			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-			// when/then
-			test.ShowClustersNotFound(t, svc.Context, svc, ctrl, uuid.NewV4())
-		})
-
-		t.Run("not allowed", func(t *testing.T) {
-			// given
-			sa := &authtestsupport.Identity{
-				Username: "foo",
-				ID:       uuid.NewV4(),
-			}
-			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-			// when/then
-			test.ShowClustersUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4())
-		})
-	})
-
-}
-func (s *ClusterControllerTestSuite) TestShowForAuthClient() {
-
-	s.T().Run("ok", func(t *testing.T) {
-		// given
-		sa := &authtestsupport.Identity{
-			Username: authsupport.ToolChainOperator,
-			ID:       uuid.NewV4(),
-		}
-		clusterPayload := newCreateClusterPayload()
-		svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-		resp := test.CreateClustersCreated(t, svc.Context, svc, ctrl, &clusterPayload)
-		location := resp.Header().Get("location")
-		require.NotEmpty(t, location)
-		// when accessing the created cluster with another identity
-		sa = &authtestsupport.Identity{
-			Username: authsupport.Auth,
-			ID:       uuid.NewV4(),
-		}
-		svc, ctrl = s.newSecuredControllerWithServiceAccount(sa)
-		splits := strings.Split(location, "/")
-		clusterID, err := uuid.FromString(splits[len(splits)-1])
-		require.NoError(t, err)
-		_, result := test.ShowForAuthClientClustersOK(t, svc.Context, svc, ctrl, clusterID)
-		// then
-		require.NotNil(t, result)
-		require.NotNil(t, result.Data)
-		assert.Equal(t, clusterPayload.Data.Name, result.Data.Name)
-		name := result.Data.Name
-		assert.Equal(t, httpsupport.AddTrailingSlashToURL(clusterPayload.Data.APIURL), result.Data.APIURL)
-		assert.Equal(t, httpsupport.AddTrailingSlashToURL(clusterPayload.Data.AppDNS), result.Data.AppDNS)
-		assert.Equal(t, false, result.Data.CapacityExhausted)
-		assert.Equal(t, fmt.Sprintf("https://console.cluster.%s/console/", name), result.Data.ConsoleURL)
-		assert.Equal(t, fmt.Sprintf("https://metrics.cluster.%s/", name), result.Data.MetricsURL)
-		assert.Equal(t, fmt.Sprintf("https://console.cluster.%s/console/", name), result.Data.LoggingURL)
-		assert.Equal(t, clusterPayload.Data.Type, result.Data.Type)
-		assert.Equal(t, clusterPayload.Data.AuthClientDefaultScope, result.Data.AuthClientDefaultScope)
-		assert.Equal(t, clusterPayload.Data.AuthClientID, result.Data.AuthClientID)
-		assert.Equal(t, clusterPayload.Data.AuthClientSecret, result.Data.AuthClientSecret)
-		assert.Equal(t, clusterPayload.Data.ServiceAccountToken, result.Data.ServiceAccountToken)
-		assert.Equal(t, clusterPayload.Data.ServiceAccountUsername, result.Data.ServiceAccountUsername)
-	})
-
-	s.T().Run("failure", func(t *testing.T) {
-
-		t.Run("not found", func(t *testing.T) {
-			// given
-			sa := &authtestsupport.Identity{
-				Username: authsupport.Auth,
-				ID:       uuid.NewV4(),
-			}
-			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-			// when/then
-			test.ShowForAuthClientClustersNotFound(t, svc.Context, svc, ctrl, uuid.NewV4())
-		})
-
-		t.Run("not allowed", func(t *testing.T) {
-			// given
-			sa := &authtestsupport.Identity{
-				Username: auth.Tenant,
-				ID:       uuid.NewV4(),
-			}
-			svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
-			// when/then
-			test.ShowForAuthClientClustersUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4())
-		})
-	})
-
 }

--- a/controller/user.go
+++ b/controller/user.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"github.com/fabric8-services/fabric8-cluster/app"
 	"github.com/fabric8-services/fabric8-common/auth"
+	"github.com/fabric8-services/fabric8-common/httpsupport"
 	"github.com/goadesign/goa"
 
 	"github.com/fabric8-services/fabric8-cluster/application"
@@ -40,10 +41,10 @@ func (c *UserController) Clusters(ctx *app.ClustersUserContext) error {
 	for _, c := range clusters {
 		clusterData := &app.ClusterData{
 			Name:              c.Name,
-			APIURL:            c.URL,
-			ConsoleURL:        c.ConsoleURL,
-			MetricsURL:        c.MetricsURL,
-			LoggingURL:        c.LoggingURL,
+			APIURL:            httpsupport.AddTrailingSlashToURL(c.URL),
+			ConsoleURL:        httpsupport.AddTrailingSlashToURL(c.ConsoleURL),
+			MetricsURL:        httpsupport.AddTrailingSlashToURL(c.MetricsURL),
+			LoggingURL:        httpsupport.AddTrailingSlashToURL(c.LoggingURL),
 			AppDNS:            c.AppDNS,
 			Type:              c.Type,
 			CapacityExhausted: c.CapacityExhausted,

--- a/controller/user_blackbox_test.go
+++ b/controller/user_blackbox_test.go
@@ -57,8 +57,8 @@ func (s *UserControllerTestSuite) TestShowClusterAvailableToUser() {
 		t.Run("list single cluster", func(t *testing.T) {
 			// given
 			identity := auth.NewIdentity()
-			cl := testsupport.CreateCluster(t, s.DB)
-			identityCluster := testsupport.CreateIdentityCluster(t, s.DB, cl, &identity.ID)
+			c := testsupport.CreateCluster(t, s.DB)
+			identityCluster := testsupport.CreateIdentityCluster(t, s.DB, c, &identity.ID)
 			require.NotNil(t, identityCluster)
 			// when
 			svc, userCtrl := s.SecuredController(identity)
@@ -66,10 +66,11 @@ func (s *UserControllerTestSuite) TestShowClusterAvailableToUser() {
 			// then
 			require.NotNil(t, clusters)
 			require.NotNil(t, clusters.Data)
-			testsupport.AssertEqualClustersData(t, []repository.Cluster{*cl}, clusters.Data)
+			expected := testsupport.Normalize(*c, testsupport.AddTrailingSlashes)
+			testsupport.AssertEqualClustersData(t, []repository.Cluster{expected}, clusters.Data)
 		})
 
-		t.Run("list multiple cluster", func(t *testing.T) {
+		t.Run("list multiple clusters", func(t *testing.T) {
 			// given
 			// create user identity
 			identity := auth.NewIdentity()
@@ -80,8 +81,7 @@ func (s *UserControllerTestSuite) TestShowClusterAvailableToUser() {
 				c := testsupport.CreateCluster(t, s.DB)
 				identityCluster := testsupport.CreateIdentityCluster(t, s.DB, c, &identityID)
 				require.NotNil(t, identityCluster)
-
-				expectedClusters[i] = *c
+				expectedClusters[i] = testsupport.Normalize(*c, testsupport.AddTrailingSlashes)
 			}
 			// when
 			svc, userCtrl := s.SecuredController(identity)

--- a/controller/user_blackbox_test.go
+++ b/controller/user_blackbox_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fabric8-services/fabric8-common/test/auth"
 
 	"context"
+
 	"github.com/fabric8-services/fabric8-cluster/cluster/repository"
 	"github.com/fabric8-services/fabric8-cluster/gormtestsupport"
 	"github.com/goadesign/goa"
@@ -45,34 +46,27 @@ func (s *UserControllerTestSuite) TestShowClusterAvailableToUser() {
 		t.Run("empty", func(t *testing.T) {
 			// given
 			identity := auth.NewIdentity()
-
 			// when
 			svc, userCtrl := s.SecuredController(identity)
 			_, clusters := test.ClustersUserOK(t, svc.Context, svc, userCtrl)
-
 			// then
 			require.NotNil(t, clusters)
 			assert.Empty(t, clusters.Data)
-
 		})
 
 		t.Run("list single cluster", func(t *testing.T) {
 			// given
 			identity := auth.NewIdentity()
-
 			cl := testsupport.CreateCluster(t, s.DB)
 			identityCluster := testsupport.CreateIdentityCluster(t, s.DB, cl, &identity.ID)
 			require.NotNil(t, identityCluster)
-
 			// when
 			svc, userCtrl := s.SecuredController(identity)
 			_, clusters := test.ClustersUserOK(t, svc.Context, svc, userCtrl)
-
 			// then
 			require.NotNil(t, clusters)
 			require.NotNil(t, clusters.Data)
-
-			testsupport.AssertEqualClusterData(t, []repository.Cluster{*cl}, clusters.Data)
+			testsupport.AssertEqualClustersData(t, []repository.Cluster{*cl}, clusters.Data)
 		})
 
 		t.Run("list multiple cluster", func(t *testing.T) {
@@ -80,7 +74,6 @@ func (s *UserControllerTestSuite) TestShowClusterAvailableToUser() {
 			// create user identity
 			identity := auth.NewIdentity()
 			identityID := identity.ID
-
 			expectedClusters := make([]repository.Cluster, 3)
 			// create random cluster and cluster identity for user
 			for i := range expectedClusters {
@@ -90,16 +83,13 @@ func (s *UserControllerTestSuite) TestShowClusterAvailableToUser() {
 
 				expectedClusters[i] = *c
 			}
-
 			// when
 			svc, userCtrl := s.SecuredController(identity)
 			_, clusters := test.ClustersUserOK(t, svc.Context, svc, userCtrl)
-
 			// then
 			require.NotNil(t, clusters)
 			require.NotNil(t, clusters.Data)
-
-			testsupport.AssertEqualClusterData(t, expectedClusters, clusters.Data)
+			testsupport.AssertEqualClustersData(t, expectedClusters, clusters.Data)
 		})
 	})
 

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func main() {
 		}, "failed to create or save cluster")
 	}
 	// Initialize cluster config watcher
-	haltWatcher, _, err := appDB.ClusterService().InitializeClusterWatcher()
+	haltWatcher, err := appDB.ClusterService().InitializeClusterWatcher()
 	if err != nil {
 		log.Panic(context.TODO(), map[string]interface{}{
 			"err": err,

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/fabric8-services/fabric8-cluster/app"
 	"github.com/fabric8-services/fabric8-cluster/application/transaction"
 	"github.com/fabric8-services/fabric8-cluster/configuration"
@@ -20,7 +21,7 @@ import (
 	"github.com/fabric8-services/fabric8-common/goamiddleware"
 	"github.com/fabric8-services/fabric8-common/log"
 	"github.com/goadesign/goa"
-	"github.com/goadesign/goa/logging/logrus"
+	goalogrus "github.com/goadesign/goa/logging/logrus"
 	"github.com/goadesign/goa/middleware"
 	"github.com/goadesign/goa/middleware/gzip"
 	"github.com/goadesign/goa/middleware/security/jwt"
@@ -146,7 +147,7 @@ func main() {
 		}, "failed to create or save cluster")
 	}
 	// Initialize cluster config watcher
-	haltWatcher, err := appDB.ClusterService().InitializeClusterWatcher()
+	haltWatcher, _, err := appDB.ClusterService().InitializeClusterWatcher()
 	if err != nil {
 		log.Panic(context.TODO(), map[string]interface{}{
 			"err": err,
@@ -174,7 +175,7 @@ func main() {
 	app.MountStatusController(service, statusCtrl)
 
 	// Mount "clusters" controller
-	clustersCtrl := controller.NewClustersController(service, config, appDB)
+	clustersCtrl := controller.NewClustersController(service, appDB)
 	app.MountClustersController(service, clustersCtrl)
 
 	// Mount "user" controller

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-cluster/cluster/repository"
@@ -31,24 +30,23 @@ func CreateCluster(t *testing.T, db *gorm.DB) *repository.Cluster {
 	return cluster
 }
 
+// NewCluster returns a new cluster with random values for all fields
 func NewCluster() *repository.Cluster {
-	random := uuid.NewV4()
 	return &repository.Cluster{
-		ClusterID:         random,
-		AppDNS:            random.String(),
-		AuthClientID:      random.String(),
-		AuthClientSecret:  random.String(),
-		AuthDefaultScope:  random.String(),
-		ConsoleURL:        random.String(),
-		LoggingURL:        random.String(),
-		MetricsURL:        random.String(),
-		Name:              random.String(),
-		SAToken:           random.String(),
-		SAUsername:        random.String(),
+		AppDNS:            uuid.NewV4().String(),
+		AuthClientID:      uuid.NewV4().String(),
+		AuthClientSecret:  uuid.NewV4().String(),
+		AuthDefaultScope:  uuid.NewV4().String(),
+		ConsoleURL:        uuid.NewV4().String(),
+		LoggingURL:        uuid.NewV4().String(),
+		MetricsURL:        uuid.NewV4().String(),
+		Name:              uuid.NewV4().String(),
+		SAToken:           uuid.NewV4().String(),
+		SAUsername:        uuid.NewV4().String(),
 		SATokenEncrypted:  true,
-		TokenProviderID:   random.String(),
-		Type:              random.String(),
-		URL:               fmt.Sprintf("http://%s/", random.String()),
+		TokenProviderID:   uuid.NewV4().String(),
+		Type:              uuid.NewV4().String(),
+		URL:               "http://" + uuid.NewV4().String() + "/",
 		CapacityExhausted: false,
 	}
 }

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-cluster/cluster/repository"
@@ -31,21 +32,23 @@ func CreateCluster(t *testing.T, db *gorm.DB) *repository.Cluster {
 }
 
 func NewCluster() *repository.Cluster {
+	random := uuid.NewV4()
 	return &repository.Cluster{
-		AppDNS:            uuid.NewV4().String(),
-		AuthClientID:      uuid.NewV4().String(),
-		AuthClientSecret:  uuid.NewV4().String(),
-		AuthDefaultScope:  uuid.NewV4().String(),
-		ConsoleURL:        uuid.NewV4().String(),
-		LoggingURL:        uuid.NewV4().String(),
-		MetricsURL:        uuid.NewV4().String(),
-		Name:              uuid.NewV4().String(),
-		SAToken:           uuid.NewV4().String(),
-		SAUsername:        uuid.NewV4().String(),
+		ClusterID:         random,
+		AppDNS:            random.String(),
+		AuthClientID:      random.String(),
+		AuthClientSecret:  random.String(),
+		AuthDefaultScope:  random.String(),
+		ConsoleURL:        random.String(),
+		LoggingURL:        random.String(),
+		MetricsURL:        random.String(),
+		Name:              random.String(),
+		SAToken:           random.String(),
+		SAUsername:        random.String(),
 		SATokenEncrypted:  true,
-		TokenProviderID:   uuid.NewV4().String(),
-		Type:              uuid.NewV4().String(),
-		URL:               "http://" + uuid.NewV4().String() + "/",
+		TokenProviderID:   random.String(),
+		Type:              random.String(),
+		URL:               fmt.Sprintf("http://%s/", random.String()),
 		CapacityExhausted: false,
 	}
 }
@@ -58,8 +61,8 @@ func AssertEqualClusters(t *testing.T, expected, actual *repository.Cluster) {
 func AssertEqualClusterDetails(t *testing.T, expected, actual *repository.Cluster) {
 	require.NotNil(t, expected)
 	require.NotNil(t, actual)
-	t.Logf("verifying cluster %+v", actual)
-	t.Logf("expected cluster %+v", expected)
+	// t.Logf("verifying cluster %+v", actual)
+	// t.Logf("expected cluster %+v", expected)
 	assert.Equal(t, expected.URL, actual.URL)
 	assert.Equal(t, expected.Type, actual.Type)
 	assert.Equal(t, expected.TokenProviderID, actual.TokenProviderID)

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -57,7 +57,7 @@ func NewCluster() *repository.Cluster {
 type NormalizeCluster func(repository.Cluster) repository.Cluster
 
 // AddTrailingSlashes a normalize function which converts all URL by adding a trailing
-// slash if neede
+// slash if needed
 var AddTrailingSlashes = func(source repository.Cluster) repository.Cluster {
 	source.URL = httpsupport.AddTrailingSlashToURL(source.URL)
 	source.ConsoleURL = httpsupport.AddTrailingSlashToURL(source.ConsoleURL)
@@ -76,8 +76,7 @@ func Normalize(source repository.Cluster, changes ...NormalizeCluster) repositor
 	return result
 }
 
-// AssertClusters verifies that the `actual` cluster belongs to the `expected`,
-// and compares all fields including sensitive details if `expectSensitiveInfo` is `true`
+// AssertClusters verifies that the `actual` cluster belongs to the `expected`
 func AssertClusters(t *testing.T, expected []repository.Cluster, actual *repository.Cluster) {
 	for _, e := range expected {
 		if e.ClusterID == actual.ClusterID {


### PR DESCRIPTION
also:
- update to latest `fabric8-common` to remove an annoying error
    message after each test
- run integration tests on a single processor to avoid concurrent
    writes in the database, which result in assertion errors

Fixes #54

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>