### PR TITLE
refactor: move security checks to service layer

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -25,9 +25,11 @@ type ClusterService interface {
 	CreateOrSaveCluster(ctx context.Context, clustr *repository.Cluster) error
 	InitializeClusterWatcher() (func() error, error)
 	Load(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
+	LoadForAuth(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
 	LinkIdentityToCluster(ctx context.Context, identityID uuid.UUID, clusterURL string, ignoreError bool) error
 	RemoveIdentityToClusterLink(ctx context.Context, identityID uuid.UUID, clusterURL string) error
 	List(ctx context.Context) ([]repository.Cluster, error)
+	ListForAuth(ctx context.Context) ([]repository.Cluster, error)
 }
 
 //Services creates instances of service layer objects

--- a/cluster/repository/cluster_repository_blackbox_test.go
+++ b/cluster/repository/cluster_repository_blackbox_test.go
@@ -41,7 +41,7 @@ func (s *clusterTestSuite) TestCreateAndLoadClusterOK() {
 	loaded, err := s.repo.Load(context.Background(), cluster1.ClusterID)
 	// then
 	require.NoError(s.T(), err)
-	test.AssertEqualCluster(s.T(), cluster1, loaded)
+	test.AssertEqualCluster(s.T(), cluster1, loaded, true)
 }
 
 func (s *clusterTestSuite) TestCreateAndLoadClusterByURLOK() {
@@ -52,7 +52,7 @@ func (s *clusterTestSuite) TestCreateAndLoadClusterByURLOK() {
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster1.URL)
 	// then
 	require.NoError(s.T(), err)
-	test.AssertEqualCluster(s.T(), cluster1, loaded)
+	test.AssertEqualCluster(s.T(), cluster1, loaded, true)
 }
 
 func (s *clusterTestSuite) TestCreateAndLoadClusterByURLFail() {
@@ -76,7 +76,7 @@ func (s *clusterTestSuite) TestCreateOKInCreateOrSave() {
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster.URL)
 	// then
 	require.NoError(s.T(), err)
-	test.AssertEqualCluster(s.T(), cluster, loaded)
+	test.AssertEqualCluster(s.T(), cluster, loaded, true)
 }
 
 func (s *clusterTestSuite) TestSaveOKInCreateOrSave() {
@@ -86,7 +86,7 @@ func (s *clusterTestSuite) TestSaveOKInCreateOrSave() {
 	s.repo.CreateOrSave(context.Background(), cluster)
 	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster.URL)
 	require.NoError(s.T(), err)
-	test.AssertEqualCluster(s.T(), cluster, loaded)
+	test.AssertEqualCluster(s.T(), cluster, loaded, true)
 	// update cluster details
 	cluster.AppDNS = uuid.NewV4().String()
 	cluster.AuthClientID = uuid.NewV4().String()
@@ -107,7 +107,7 @@ func (s *clusterTestSuite) TestSaveOKInCreateOrSave() {
 	loaded, err = s.repo.LoadClusterByURL(context.Background(), cluster.URL)
 	// then
 	require.NoError(s.T(), err)
-	test.AssertEqualCluster(s.T(), cluster, loaded)
+	test.AssertEqualCluster(s.T(), cluster, loaded, true)
 }
 
 func (s *clusterTestSuite) TestDeleteOK() {
@@ -122,7 +122,7 @@ func (s *clusterTestSuite) TestDeleteOK() {
 	test.AssertError(s.T(), err, errors.NotFoundError{}, "cluster with id '%s' not found", cluster1.ClusterID)
 	loaded, err := s.repo.Load(context.Background(), cluster2.ClusterID)
 	require.NoError(s.T(), err)
-	test.AssertEqualCluster(s.T(), cluster2, loaded)
+	test.AssertEqualCluster(s.T(), cluster2, loaded, true)
 }
 
 func (s *clusterTestSuite) TestDeleteUnknownFails() {
@@ -167,10 +167,10 @@ func (s *clusterTestSuite) TestSaveOK() {
 	require.NoError(s.T(), err)
 	loaded1, err := s.repo.Load(context.Background(), cluster1.ClusterID)
 	require.NoError(s.T(), err)
-	test.AssertEqualCluster(s.T(), cluster1, loaded1)
+	test.AssertEqualCluster(s.T(), cluster1, loaded1, true)
 	loaded2, err := s.repo.Load(context.Background(), cluster2.ClusterID)
 	require.NoError(s.T(), err)
-	test.AssertEqualCluster(s.T(), cluster2, loaded2)
+	test.AssertEqualCluster(s.T(), cluster2, loaded2, true)
 }
 
 func (s *clusterTestSuite) TestSaveUnknownFails() {
@@ -204,7 +204,7 @@ func (s *clusterTestSuite) TestQueryOK() {
 	// then
 	require.NoError(s.T(), err)
 	require.Len(s.T(), clusters, 1)
-	test.AssertEqualCluster(s.T(), cluster1, &clusters[0])
+	test.AssertEqualCluster(s.T(), cluster1, &clusters[0], true)
 }
 
 func (s *clusterTestSuite) TestList() {
@@ -216,6 +216,6 @@ func (s *clusterTestSuite) TestList() {
 	// then
 	require.NoError(s.T(), err)
 	require.Len(s.T(), clusters, 2)
-	test.AssertClusters(s.T(), clusters, cluster1)
-	test.AssertClusters(s.T(), clusters, cluster2)
+	test.AssertClusters(s.T(), clusters, cluster1, true)
+	test.AssertClusters(s.T(), clusters, cluster2, true)
 }

--- a/cluster/service/cluster_service.go
+++ b/cluster/service/cluster_service.go
@@ -110,6 +110,7 @@ func (c clusterService) Load(ctx context.Context, clusterID uuid.UUID) (*reposit
 	result.SAToken = ""
 	result.SAUsername = ""
 	result.TokenProviderID = ""
+	result.SATokenEncrypted = false
 	return result, nil
 }
 
@@ -422,7 +423,7 @@ func (c clusterService) List(ctx context.Context) ([]repository.Cluster, error) 
 	return clusters, nil
 }
 
-// List lists ALL clusters, including sensitive informatio
+// List lists ALL clusters, including sensitive information
 // This method is allowed for the `Auth` service account only
 func (c clusterService) ListForAuth(ctx context.Context) ([]repository.Cluster, error) {
 	if !auth.IsSpecificServiceAccount(ctx, auth.Auth) {

--- a/cluster/service/cluster_service_blackbox_test.go
+++ b/cluster/service/cluster_service_blackbox_test.go
@@ -78,7 +78,7 @@ func (s *ClusterServiceTestSuite) TestCreateOrSaveCluster() {
 			assert.Equal(t, cluster.OCP, c.Type)
 			assert.Equal(t, fmt.Sprintf("https://cluster.%s/", name), c.AppDNS)
 			assert.Equal(t, fmt.Sprintf("https://api.cluster.%s/", name), c.URL)
-			assert.Equal(t, false, c.CapacityExhausted)
+			assert.Equal(t, true, c.CapacityExhausted)
 			assert.Equal(t, "ServiceAccountToken", c.SAToken)
 			assert.Equal(t, "ServiceAccountUsername", c.SAUsername)
 			assert.Equal(t, "AuthClientID", c.AuthClientID)
@@ -104,7 +104,7 @@ func (s *ClusterServiceTestSuite) TestCreateOrSaveCluster() {
 			assert.Equal(t, cluster.OCP, c.Type)
 			assert.Equal(t, fmt.Sprintf("https://cluster.%s/", name), c.AppDNS)
 			assert.Equal(t, fmt.Sprintf("https://api.cluster.%s/", name), c.URL)
-			assert.Equal(t, false, c.CapacityExhausted)
+			assert.Equal(t, true, c.CapacityExhausted)
 			assert.Equal(t, "ServiceAccountToken", c.SAToken)
 			assert.Equal(t, "ServiceAccountUsername", c.SAUsername)
 			assert.Equal(t, "AuthClientID", c.AuthClientID)
@@ -640,9 +640,10 @@ func newTestCluster() *repository.Cluster {
 		ConsoleURL:        fmt.Sprintf("https://console.cluster.%s", name),
 		LoggingURL:        fmt.Sprintf("https://logging.cluster.%s", name),
 		MetricsURL:        fmt.Sprintf("https://metrics.cluster.%s", name),
-		CapacityExhausted: false,
+		CapacityExhausted: true,
 		SAToken:           "ServiceAccountToken",
 		SAUsername:        "ServiceAccountUsername",
+		SATokenEncrypted:  true,
 		TokenProviderID:   "TokenProviderID",
 		AuthClientID:      "AuthClientID",
 		AuthClientSecret:  "AuthClientSecret",

--- a/cluster/service/cluster_service_blackbox_test.go
+++ b/cluster/service/cluster_service_blackbox_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/fabric8-services/fabric8-cluster/configuration"
 	"github.com/fabric8-services/fabric8-cluster/gormtestsupport"
 	"github.com/fabric8-services/fabric8-cluster/test"
+	clustertestsupport "github.com/fabric8-services/fabric8-cluster/test"
 	"github.com/fabric8-services/fabric8-common/errors"
 	testsupport "github.com/fabric8-services/fabric8-common/test"
+	authtestsupport "github.com/fabric8-services/fabric8-common/test/auth"
 
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
@@ -39,20 +41,20 @@ func (s *ClusterServiceTestSuite) TestCreateOrSaveClusterFromConfigOK() {
 	err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
 	// then
 	require.NoError(s.T(), err)
-
+	// lookup OSO clusters
 	osoClusters, err := s.Application.Clusters().Query(func(db *gorm.DB) *gorm.DB {
 		return db.Where("type = ?", cluster.OSO)
 	})
 	require.NoError(s.T(), err)
 	assert.Len(s.T(), osoClusters, 3)
-
+	// lookup OSD cluster
 	osdClusters, err := s.Application.Clusters().Query(func(db *gorm.DB) *gorm.DB {
 		return db.Where("type = ?", cluster.OSD)
 	})
 	require.NoError(s.T(), err)
 	assert.Len(s.T(), osdClusters, 1)
-
-	verifyClusters(s.T(), append(osoClusters, osdClusters...), s.Configuration.GetClusters())
+	// verify all records
+	verifyClusters(s.T(), append(osoClusters, osdClusters...), s.Configuration.GetClusters(), true)
 }
 
 func (s *ClusterServiceTestSuite) TestCreateOrSaveCluster() {
@@ -399,26 +401,232 @@ func (s *ClusterServiceTestSuite) TestCreateOrSaveCluster() {
 func (s *ClusterServiceTestSuite) TestLoad() {
 
 	s.T().Run("ok", func(t *testing.T) {
-		// given
-		c := newTestCluster()
-		err := s.Application.ClusterService().CreateOrSaveCluster(context.Background(), c)
-		require.NoError(t, err)
-		// when
-		result, err := s.Application.ClusterService().Load(context.Background(), c.ClusterID)
-		// then
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		test.AssertEqualCluster(t, c, result)
+
+		for _, saName := range []string{"fabric8-oso-proxy", "fabric8-tenant", "fabric8-jenkins-idler", "fabric8-jenkins-proxy", "fabric8-auth"} {
+			t.Run(saName, func(t *testing.T) {
+				// given
+				c := newTestCluster()
+				err := s.Application.ClusterService().CreateOrSaveCluster(context.Background(), c)
+				require.NoError(t, err)
+				sa := &authtestsupport.Identity{
+					Username: saName,
+					ID:       uuid.NewV4(),
+				}
+				ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+				require.NoError(t, err)
+				// when
+				result, err := s.Application.ClusterService().Load(ctx, c.ClusterID)
+				// then
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				test.AssertEqualCluster(t, c, result, false)
+			})
+		}
 	})
 
-	s.T().Run("not found", func(t *testing.T) {
-		// given
-		id := uuid.NewV4()
-		// when
-		_, err := s.Application.ClusterService().Load(context.Background(), id)
-		// then
-		require.Error(t, err)
-		testsupport.AssertError(t, err, errors.NotFoundError{}, errors.NewNotFoundError("cluster", id.String()).Error())
+	s.T().Run("failures", func(t *testing.T) {
+
+		t.Run("unauthorized", func(t *testing.T) {
+			// given
+			c := newTestCluster()
+			err := s.Application.ClusterService().CreateOrSaveCluster(context.Background(), c)
+			require.NoError(t, err)
+			sa := &authtestsupport.Identity{
+				Username: "foo",
+				ID:       uuid.NewV4(),
+			}
+			ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+			require.NoError(t, err)
+			// when
+			_, err = s.Application.ClusterService().Load(ctx, c.ClusterID)
+			// then
+			testsupport.AssertError(t, err, errors.UnauthorizedError{}, "unauthorized access to cluster info")
+		})
+
+		t.Run("not found", func(t *testing.T) {
+			// given
+			c := newTestCluster()
+			err := s.Application.ClusterService().CreateOrSaveCluster(context.Background(), c)
+			require.NoError(t, err)
+			sa := &authtestsupport.Identity{
+				Username: "fabric8-auth",
+				ID:       uuid.NewV4(),
+			}
+			ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+			require.NoError(t, err)
+			id := uuid.NewV4()
+			// when
+			_, err = s.Application.ClusterService().Load(ctx, id)
+			// then
+			require.Error(t, err)
+			testsupport.AssertError(t, err, errors.NotFoundError{}, errors.NewNotFoundError("cluster", id.String()).Error())
+		})
+	})
+}
+
+func (s *ClusterServiceTestSuite) TestLoadForAuth() {
+
+	s.T().Run("ok", func(t *testing.T) {
+		for _, saName := range []string{"fabric8-auth"} {
+			t.Run(saName, func(t *testing.T) {
+				// given
+				c := newTestCluster()
+				err := s.Application.ClusterService().CreateOrSaveCluster(context.Background(), c)
+				require.NoError(t, err)
+				sa := &authtestsupport.Identity{
+					Username: saName,
+					ID:       uuid.NewV4(),
+				}
+				ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+				require.NoError(t, err)
+				// when
+				result, err := s.Application.ClusterService().LoadForAuth(ctx, c.ClusterID)
+				// then
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				test.AssertEqualCluster(t, c, result, true)
+			})
+		}
+	})
+
+	s.T().Run("failures", func(t *testing.T) {
+
+		t.Run("unauthorized", func(t *testing.T) {
+			for _, saName := range []string{"fabric8-oso-proxy", "fabric8-tenant", "fabric8-jenkins-idler", "fabric8-jenkins-proxy", "other"} {
+				t.Run(saName, func(t *testing.T) {
+					// given
+					c := newTestCluster()
+					err := s.Application.ClusterService().CreateOrSaveCluster(context.Background(), c)
+					require.NoError(t, err)
+					sa := &authtestsupport.Identity{
+						Username: "foo",
+						ID:       uuid.NewV4(),
+					}
+					ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+					require.NoError(t, err)
+					// when
+					_, err = s.Application.ClusterService().Load(ctx, c.ClusterID)
+					// then
+					testsupport.AssertError(t, err, errors.UnauthorizedError{}, "unauthorized access to cluster info")
+				})
+			}
+		})
+
+		t.Run("not found", func(t *testing.T) {
+			// given
+			c := newTestCluster()
+			err := s.Application.ClusterService().CreateOrSaveCluster(context.Background(), c)
+			require.NoError(t, err)
+			sa := &authtestsupport.Identity{
+				Username: "fabric8-auth", // use a SA that is not unauthorized
+				ID:       uuid.NewV4(),
+			}
+			ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+			require.NoError(t, err)
+			id := uuid.NewV4()
+			// when
+			_, err = s.Application.ClusterService().Load(ctx, id)
+			// then
+			require.Error(t, err)
+			testsupport.AssertError(t, err, errors.NotFoundError{}, errors.NewNotFoundError("cluster", id.String()).Error())
+		})
+	})
+}
+
+func (s *ClusterServiceTestSuite) TestList() {
+	// given
+	clustertestsupport.CreateCluster(s.T(), s.DB) // add extra cluster
+	err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
+	require.NoError(s.T(), err)
+
+	s.T().Run("ok", func(t *testing.T) {
+		for _, saName := range []string{"fabric8-oso-proxy", "fabric8-tenant", "fabric8-jenkins-idler", "fabric8-jenkins-proxy", "fabric8-auth"} {
+			t.Run(saName, func(t *testing.T) {
+				// given
+				sa := &authtestsupport.Identity{
+					Username: saName,
+					ID:       uuid.NewV4(),
+				}
+				ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+				require.NoError(t, err)
+				// when
+				result, err := s.Application.ClusterService().List(ctx)
+				// then
+				require.NoError(t, err)
+				expected, err := repository.NewClusterRepository(s.DB).List(context.Background())
+				require.NoError(t, err)
+				clustertestsupport.AssertEqualClusters(t, expected, result, false)
+			})
+		}
+	})
+
+	s.T().Run("failures", func(t *testing.T) {
+		t.Run("unauthorized", func(t *testing.T) {
+			// given
+			err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
+			require.NoError(t, err)
+			sa := &authtestsupport.Identity{
+				Username: "foo",
+				ID:       uuid.NewV4(),
+			}
+			ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+			require.NoError(t, err)
+			// when
+			_, err = s.Application.ClusterService().List(ctx)
+			// then
+			require.Error(t, err)
+			testsupport.AssertError(t, err, errors.UnauthorizedError{}, "unauthorized access to clusters info")
+		})
+	})
+}
+func (s *ClusterServiceTestSuite) TestListForAuth() {
+	// given
+	clustertestsupport.CreateCluster(s.T(), s.DB) // add extra cluster
+	err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
+	require.NoError(s.T(), err)
+
+	s.T().Run("ok", func(t *testing.T) {
+		for _, saName := range []string{"fabric8-auth"} {
+			t.Run(saName, func(t *testing.T) {
+				// given
+				sa := &authtestsupport.Identity{
+					Username: saName,
+					ID:       uuid.NewV4(),
+				}
+				ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+				require.NoError(t, err)
+				// when
+				result, err := s.Application.ClusterService().ListForAuth(ctx)
+				// then
+				require.NoError(t, err)
+				expected, err := repository.NewClusterRepository(s.DB).List(context.Background())
+				require.NoError(t, err)
+				clustertestsupport.AssertEqualClusters(t, expected, result, true)
+			})
+		}
+	})
+
+	s.T().Run("failures", func(t *testing.T) {
+		t.Run("unauthorized", func(t *testing.T) {
+			for _, saName := range []string{"fabric8-oso-proxy", "fabric8-tenant", "fabric8-jenkins-idler", "fabric8-jenkins-proxy", "other"} {
+				t.Run(saName, func(t *testing.T) {
+					// given
+					err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
+					require.NoError(t, err)
+					sa := &authtestsupport.Identity{
+						Username: saName,
+						ID:       uuid.NewV4(),
+					}
+					ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+					require.NoError(t, err)
+					// when
+					_, err = s.Application.ClusterService().ListForAuth(ctx)
+					// then
+					require.Error(t, err)
+					testsupport.AssertError(t, err, errors.UnauthorizedError{}, "unauthorized access to clusters info")
+				})
+			}
+		})
 	})
 }
 
@@ -516,14 +724,13 @@ func (s *ClusterServiceTestSuite) TestLinkIdentityToCluster() {
 			// then
 			loaded1, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c1.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualCluster(t, c1, &loaded1.Cluster)
+			test.AssertEqualCluster(t, c1, &loaded1.Cluster, true)
 			test.AssertEqualIdentityClusters(t, identityCluster1, loaded1)
 
 			clusters, err := s.Application.IdentityClusters().ListClustersForIdentity(s.Ctx, identityID)
 			require.NoError(t, err)
-
 			assert.Len(t, clusters, 1)
-			test.AssertEqualCluster(t, c1, &clusters[0])
+			test.AssertEqualCluster(t, c1, &clusters[0], true)
 		})
 
 		t.Run("do not ignore if exists", func(t *testing.T) {
@@ -540,14 +747,14 @@ func (s *ClusterServiceTestSuite) TestLinkIdentityToCluster() {
 			// then
 			loaded1, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c1.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualCluster(t, c1, &loaded1.Cluster)
+			test.AssertEqualCluster(t, c1, &loaded1.Cluster, true)
 			test.AssertEqualIdentityClusters(t, identityCluster1, loaded1)
 
 			clusters, err := s.Application.IdentityClusters().ListClustersForIdentity(s.Ctx, identityID)
 			require.NoError(t, err)
 
 			assert.Len(t, clusters, 1)
-			test.AssertEqualCluster(t, c1, &clusters[0])
+			test.AssertEqualCluster(t, c1, &clusters[0], true)
 		})
 
 		t.Run("link multiple clusters to single identity", func(t *testing.T) {
@@ -570,12 +777,12 @@ func (s *ClusterServiceTestSuite) TestLinkIdentityToCluster() {
 			// then
 			loaded1, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c1.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualCluster(t, c1, &loaded1.Cluster)
+			test.AssertEqualCluster(t, c1, &loaded1.Cluster, true)
 			test.AssertEqualIdentityClusters(t, identityCluster1, loaded1)
 
 			loaded2, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c2.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualCluster(t, c2, &loaded2.Cluster)
+			test.AssertEqualCluster(t, c2, &loaded2.Cluster, true)
 			test.AssertEqualIdentityClusters(t, identityCluster2, loaded2)
 		})
 	})
@@ -633,11 +840,11 @@ func (s *ClusterServiceTestSuite) TestRemoveIdentityToClusterLink() {
 			clusters, err := s.Application.IdentityClusters().ListClustersForIdentity(s.Ctx, identityID)
 			require.NoError(t, err)
 			require.Len(t, clusters, 1)
-			test.AssertEqualCluster(t, c1, &clusters[0])
+			test.AssertEqualCluster(t, c1, &clusters[0], true)
 
 			loaded1, err := s.Application.IdentityClusters().Load(s.Ctx, identityID, c1.ClusterID)
 			require.NoError(t, err)
-			test.AssertEqualCluster(t, c1, &loaded1.Cluster)
+			test.AssertEqualCluster(t, c1, &loaded1.Cluster, true)
 			test.AssertEqualIdentityClusters(t, identityCluster1, loaded1)
 
 			_, err = s.Application.IdentityClusters().Load(s.Ctx, identityID, c2.ClusterID)
@@ -657,19 +864,6 @@ func (s *ClusterServiceTestSuite) TestRemoveIdentityToClusterLink() {
 			test.AssertError(t, err, errors.BadParameterError{}, "Bad value for parameter 'cluster-url': 'cluster with requested url %s doesn't exist'", url)
 		})
 	})
-}
-
-func (s *ClusterServiceTestSuite) TestList() {
-	// given
-	err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
-	require.NoError(s.T(), err)
-	// when
-	result, err := s.Application.ClusterService().List(context.Background())
-	// then
-	require.NoError(s.T(), err)
-	expected, err := repository.NewClusterRepository(s.DB).List(context.Background())
-	require.NoError(s.T(), err)
-	test.AssertEqualClusters(s.T(), expected, result)
 }
 
 func createTempClusterConfigFile(t *testing.T) string {
@@ -714,13 +908,13 @@ func waitForConfigUpdate(t *testing.T, config *configuration.ConfigurationData, 
 	require.Fail(t, "cluster config has not been reloaded within 3s")
 }
 
-func verifyClusters(t *testing.T, actualClusters []repository.Cluster, expectedClusters map[string]configuration.Cluster) {
+func verifyClusters(t *testing.T, actualClusters []repository.Cluster, expectedClusters map[string]configuration.Cluster, compareSensitiveInfo bool) {
 	for _, expectedCluster := range expectedClusters {
-		verifyCluster(t, actualClusters, test.ClusterFromConfigurationCluster(expectedCluster))
+		verifyCluster(t, actualClusters, test.ClusterFromConfigurationCluster(expectedCluster), compareSensitiveInfo)
 	}
 }
 
-func verifyCluster(t *testing.T, actualClusters []repository.Cluster, expectedCluster *repository.Cluster) {
+func verifyCluster(t *testing.T, actualClusters []repository.Cluster, expectedCluster *repository.Cluster, compareSensitiveInfo bool) {
 	actualCluster := test.FilterClusterByURL(expectedCluster.URL, actualClusters)
-	test.AssertEqualClusterDetails(t, expectedCluster, actualCluster)
+	test.AssertEqualClusterDetails(t, expectedCluster, actualCluster, compareSensitiveInfo)
 }


### PR DESCRIPTION
introduce distinct methods for `Load` and `List`:
- `Load(...)` and `LoadForAuth(...)`
- `List(...)` and `ListForAuth(...)`

Only the `...ForAuth(...)` methods return the sensitive
cluster details.
Those methods are restricted to the `fabric8-auth` SA.

Fixes #53

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>