### PR TITLE
feat: delete cluster info

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -25,6 +25,7 @@ type ClusterService interface {
 	CreateOrSaveCluster(ctx context.Context, clustr *repository.Cluster) error
 	InitializeClusterWatcher() (func() error, error)
 	Load(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
+	Delete(ctx context.Context, clusterID uuid.UUID) error
 	LoadForAuth(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
 	LinkIdentityToCluster(ctx context.Context, identityID uuid.UUID, clusterURL string, ignoreError bool) error
 	RemoveIdentityToClusterLink(ctx context.Context, identityID uuid.UUID, clusterURL string) error

--- a/cluster/repository/cluster_repository.go
+++ b/cluster/repository/cluster_repository.go
@@ -197,13 +197,11 @@ func (m *GormClusterRepository) CreateOrSave(ctx context.Context, c *Cluster) er
 }
 
 // Delete removes a single record. This is a hard delete!
+// Also, remove all identity/cluster relationship associated with this cluster to remove.
 func (m *GormClusterRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "cluster", "delete"}, time.Now())
-
 	obj := Cluster{ClusterID: id}
-
 	result := m.db.Delete(&obj)
-
 	if result.Error != nil {
 		log.Error(ctx, map[string]interface{}{
 			"cluster_id": id.String(),

--- a/cluster/repository/identity_cluster.go
+++ b/cluster/repository/identity_cluster.go
@@ -103,7 +103,7 @@ func (m *GormIdentityClusterRepository) Create(ctx context.Context, c *IdentityC
 	return nil
 }
 
-// Delete removes a single record.
+// Delete removes the identity/cluster relationship identified by the given `identityID` and `clusterID`
 func (m *GormIdentityClusterRepository) Delete(ctx context.Context, identityID, clusterID uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "identity_cluster", "delete"}, time.Now())
 

--- a/cluster/service/cluster_service.go
+++ b/cluster/service/cluster_service.go
@@ -250,7 +250,7 @@ func ValidateURL(urlStr *string) error {
 
 // Delete deletes the cluster identified by the given `clusterID`
 func (c clusterService) Delete(ctx context.Context, clusterID uuid.UUID) error {
-	// check that the token belongs to a user
+	// check that the token belongs to a the `toolchain operator` SA
 	if !auth.IsSpecificServiceAccount(ctx, auth.ToolChainOperator) {
 		return errors.NewUnauthorizedError("unauthorized access to delete a cluster configuration")
 	}

--- a/cluster/service/cluster_service.go
+++ b/cluster/service/cluster_service.go
@@ -248,6 +248,15 @@ func ValidateURL(urlStr *string) error {
 	return nil
 }
 
+// Delete deletes the cluster identified by the given `clusterID`
+func (c clusterService) Delete(ctx context.Context, clusterID uuid.UUID) error {
+	// check that the token belongs to a user
+	if !auth.IsSpecificServiceAccount(ctx, auth.ToolChainOperator) {
+		return errors.NewUnauthorizedError("unauthorized access to delete a cluster configuration")
+	}
+	return c.Repositories().Clusters().Delete(ctx, clusterID)
+}
+
 // InitializeClusterWatcher initializes a file watcher for the cluster config file
 // When the file is updated the configuration synchronously reload the cluster configuration
 func (c clusterService) InitializeClusterWatcher() (func() error, error) {

--- a/cluster/service/cluster_service.go
+++ b/cluster/service/cluster_service.go
@@ -250,7 +250,7 @@ func ValidateURL(urlStr *string) error {
 
 // Delete deletes the cluster identified by the given `clusterID`
 func (c clusterService) Delete(ctx context.Context, clusterID uuid.UUID) error {
-	// check that the token belongs to a the `toolchain operator` SA
+	// check that the token belongs to the `toolchain operator` SA
 	if !auth.IsSpecificServiceAccount(ctx, auth.ToolChainOperator) {
 		return errors.NewUnauthorizedError("unauthorized access to delete a cluster configuration")
 	}

--- a/cluster/service/cluster_service_blackbox_test.go
+++ b/cluster/service/cluster_service_blackbox_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fabric8-services/fabric8-common/auth"
+
 	"github.com/fabric8-services/fabric8-cluster/gormapplication"
 
 	"github.com/fabric8-services/fabric8-cluster/cluster"
@@ -16,7 +18,6 @@ import (
 	"github.com/fabric8-services/fabric8-cluster/configuration"
 	"github.com/fabric8-services/fabric8-cluster/gormtestsupport"
 	"github.com/fabric8-services/fabric8-cluster/test"
-	clustertestsupport "github.com/fabric8-services/fabric8-cluster/test"
 	"github.com/fabric8-services/fabric8-common/errors"
 	testsupport "github.com/fabric8-services/fabric8-common/test"
 	authtestsupport "github.com/fabric8-services/fabric8-common/test/auth"
@@ -535,7 +536,7 @@ func (s *ClusterServiceTestSuite) TestLoadForAuth() {
 
 func (s *ClusterServiceTestSuite) TestList() {
 	// given
-	clustertestsupport.CreateCluster(s.T(), s.DB) // add extra cluster
+	test.CreateCluster(s.T(), s.DB) // add extra cluster
 	err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
 	require.NoError(s.T(), err)
 
@@ -555,7 +556,7 @@ func (s *ClusterServiceTestSuite) TestList() {
 				require.NoError(t, err)
 				expected, err := repository.NewClusterRepository(s.DB).List(context.Background())
 				require.NoError(t, err)
-				clustertestsupport.AssertEqualClusters(t, expected, result, false)
+				test.AssertEqualClusters(t, expected, result, false)
 			})
 		}
 	})
@@ -581,7 +582,7 @@ func (s *ClusterServiceTestSuite) TestList() {
 }
 func (s *ClusterServiceTestSuite) TestListForAuth() {
 	// given
-	clustertestsupport.CreateCluster(s.T(), s.DB) // add extra cluster
+	test.CreateCluster(s.T(), s.DB) // add extra cluster
 	err := s.Application.ClusterService().CreateOrSaveClusterFromConfig(context.Background())
 	require.NoError(s.T(), err)
 
@@ -601,7 +602,7 @@ func (s *ClusterServiceTestSuite) TestListForAuth() {
 				require.NoError(t, err)
 				expected, err := repository.NewClusterRepository(s.DB).List(context.Background())
 				require.NoError(t, err)
-				clustertestsupport.AssertEqualClusters(t, expected, result, true)
+				test.AssertEqualClusters(t, expected, result, true)
 			})
 		}
 	})
@@ -628,6 +629,54 @@ func (s *ClusterServiceTestSuite) TestListForAuth() {
 			}
 		})
 	})
+}
+
+func (s *ClusterServiceTestSuite) TestDelete() {
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		c := test.CreateCluster(t, s.DB)
+		sa := &authtestsupport.Identity{
+			Username: auth.ToolChainOperator,
+			ID:       uuid.NewV4(),
+		}
+		ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+		require.NoError(t, err)
+		// when
+		err = s.Application.ClusterService().Delete(ctx, c.ClusterID)
+		// then
+		require.NoError(t, err)
+		// check that
+		c, err = repository.NewClusterRepository(s.DB).Load(ctx, c.ClusterID)
+		require.Error(t, err)
+		assert.IsType(t, errors.NotFoundError{}, err)
+		require.Nil(t, c)
+	})
+
+	s.T().Run("failures", func(t *testing.T) {
+		t.Run("unauthorized", func(t *testing.T) {
+			// given
+			c := test.CreateCluster(t, s.DB)
+
+			for _, saName := range []string{"fabric8-auth", "fabric8-oso-proxy", "fabric8-tenant", "fabric8-jenkins-idler", "fabric8-jenkins-proxy", "other"} {
+				t.Run(saName, func(t *testing.T) {
+					// given
+					sa := &authtestsupport.Identity{
+						Username: saName,
+						ID:       uuid.NewV4(),
+					}
+					ctx, err := authtestsupport.EmbedServiceAccountTokenInContext(context.Background(), sa)
+					require.NoError(t, err)
+					// when
+					err = s.Application.ClusterService().Delete(ctx, c.ClusterID)
+					// then
+					require.Error(t, err)
+					testsupport.AssertError(t, err, errors.UnauthorizedError{}, "unauthorized access to delete a cluster configuration")
+				})
+			}
+		})
+	})
+
 }
 
 func newTestCluster() *repository.Cluster {

--- a/controller/clusters.go
+++ b/controller/clusters.go
@@ -185,6 +185,18 @@ func (c *ClustersController) Create(ctx *app.CreateClustersContext) error {
 	return ctx.Created()
 }
 
+// Delete deletes the cluster identified by the `clusterID` param
+func (c *ClustersController) Delete(ctx *app.DeleteClustersContext) error {
+	err := c.app.ClusterService().Delete(ctx, ctx.ClusterID)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"error": err,
+		}, "error while deleting a cluster configuration")
+		return app.JSONErrorResponse(ctx, err)
+	}
+	return ctx.NoContent()
+}
+
 // LinkIdentityToCluster populates Identity Cluster relationship
 func (c *ClustersController) LinkIdentityToCluster(ctx *app.LinkIdentityToClusterClustersContext) error {
 	if !auth.IsSpecificServiceAccount(ctx, auth.Auth) {

--- a/controller/clusters_blackbox_test.go
+++ b/controller/clusters_blackbox_test.go
@@ -300,6 +300,41 @@ func (s *ClustersControllerTestSuite) TestCreate() {
 	})
 }
 
+func (s *ClustersControllerTestSuite) TestDelete() {
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		sa := &authtestsupport.Identity{
+			Username: authsupport.ToolChainOperator,
+			ID:       uuid.NewV4(),
+		}
+		c := testsupport.CreateCluster(t, s.DB)
+		svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+		// when/then
+		test.DeleteClustersNoContent(t, svc.Context, svc, ctrl, c.ClusterID)
+	})
+
+	s.T().Run("failure", func(t *testing.T) {
+
+		t.Run("unauthorized", func(t *testing.T) {
+			// given
+			c := testsupport.CreateCluster(t, s.DB)
+			for _, saName := range []string{"fabric8-oso-proxy", "fabric8-tenant", "fabric8-jenkins-idler", "fabric8-jenkins-proxy"} {
+				t.Run(saName, func(t *testing.T) {
+					// given
+					sa := &authtestsupport.Identity{
+						Username: saName,
+						ID:       uuid.NewV4(),
+					}
+					svc, ctrl := s.newSecuredControllerWithServiceAccount(sa)
+					// when/then
+					test.DeleteClustersUnauthorized(t, svc.Context, svc, ctrl, c.ClusterID)
+				})
+			}
+		})
+	})
+}
+
 func (s *ClustersControllerTestSuite) TestLinkIdentityClusters() {
 
 	s.T().Run("ok", func(t *testing.T) {

--- a/design/clusters.go
+++ b/design/clusters.go
@@ -179,8 +179,8 @@ var _ = a.Resource("clusters", func() {
 		})
 		a.Description("Delete a cluster configuration")
 		a.Response(d.NoContent)
-		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
 

--- a/design/clusters.go
+++ b/design/clusters.go
@@ -168,6 +168,22 @@ var _ = a.Resource("clusters", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
 
+	a.Action("delete", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.DELETE("/:clusterID"),
+		)
+		a.Params(func() {
+			a.Param("clusterID", d.UUID, "the ID of the cluster to delete")
+			a.Required("clusterID")
+		})
+		a.Description("Delete a cluster configuration")
+		a.Response(d.NoContent)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+
 	a.Action("linkIdentityToCluster", func() {
 		a.Security("jwt")
 		a.Routing(


### PR DESCRIPTION
endpoint calls the new `Delete` service method
which is restricted to the `toolchain operator` SA

fixes #44

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>