### PR TITLE
feat: endpoint to return a cluster given its URL

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -12,28 +12,30 @@ Steps for adding a new Service:
 1. Add a new service interface to application/service/services.go
 2. Create an implementation of the service interface
 3. Add a new method to service.Services interface in application/service/services.go for accessing the service interface
-   defined in step 1
+defined in step 1
 4. Add a new method to application/service/factory/service_factory.go which implements the service access method
-   from step #3 and uses the service constructor from step 2
+from step #3 and uses the service constructor from step 2
 5. Add a new method to gormapplication/application.go which implements the service access method from step #3
-   and use the factory method from the step #4
+and use the factory method from the step #4
 */
-
-// ClusterService the interface for the cluster service
-type ClusterService interface {
-	CreateOrSaveClusterFromConfig(ctx context.Context) error
-	CreateOrSaveCluster(ctx context.Context, clustr *repository.Cluster) error
-	InitializeClusterWatcher() (func() error, error)
-	Load(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
-	Delete(ctx context.Context, clusterID uuid.UUID) error
-	LoadForAuth(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
-	LinkIdentityToCluster(ctx context.Context, identityID uuid.UUID, clusterURL string, ignoreError bool) error
-	RemoveIdentityToClusterLink(ctx context.Context, identityID uuid.UUID, clusterURL string) error
-	List(ctx context.Context) ([]repository.Cluster, error)
-	ListForAuth(ctx context.Context) ([]repository.Cluster, error)
-}
 
 //Services creates instances of service layer objects
 type Services interface {
 	ClusterService() ClusterService
+}
+
+// ClusterService the interface for the cluster service
+type ClusterService interface {
+	InitializeClusterWatcher() (func() error, error)
+	CreateOrSaveClusterFromConfig(ctx context.Context) error
+	CreateOrSaveCluster(ctx context.Context, clustr *repository.Cluster) error
+	Load(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
+	LoadForAuth(ctx context.Context, clusterID uuid.UUID) (*repository.Cluster, error)
+	FindByURL(ctx context.Context, clusterURL string) (*repository.Cluster, error)
+	FindByURLForAuth(ctx context.Context, clusterURL string) (*repository.Cluster, error)
+	List(ctx context.Context) ([]repository.Cluster, error)
+	ListForAuth(ctx context.Context) ([]repository.Cluster, error)
+	Delete(ctx context.Context, clusterID uuid.UUID) error
+	LinkIdentityToCluster(ctx context.Context, identityID uuid.UUID, clusterURL string, ignoreError bool) error
+	RemoveIdentityToClusterLink(ctx context.Context, identityID uuid.UUID, clusterURL string) error
 }

--- a/cluster/repository/cluster_repository_blackbox_test.go
+++ b/cluster/repository/cluster_repository_blackbox_test.go
@@ -45,28 +45,28 @@ func (s *clusterRepositoryTestSuite) TestCreateAndLoadClusterOK() {
 	test.AssertEqualCluster(s.T(), cluster1, *loaded, true)
 }
 
-func (s *clusterRepositoryTestSuite) TestCreateAndLoadClusterByURLOK() {
+func (s *clusterRepositoryTestSuite) TestCreateAndFindByURLOK() {
 	// given
 	cluster1 := test.CreateCluster(s.T(), s.DB)
 	test.CreateCluster(s.T(), s.DB) // noise
 	// when
-	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster1.URL)
+	loaded, err := s.repo.FindByURL(context.Background(), cluster1.URL)
 	// then
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), loaded)
 	test.AssertEqualCluster(s.T(), cluster1, *loaded, true)
 }
 
-func (s *clusterRepositoryTestSuite) TestCreateAndLoadClusterByURLFail() {
+func (s *clusterRepositoryTestSuite) TestCreateAndFindByURLFail() {
 	// given
 	test.CreateCluster(s.T(), s.DB)
 	test.CreateCluster(s.T(), s.DB) // noise
 	// when
 	clusterURL := uuid.NewV4().String()
-	loaded, err := s.repo.LoadClusterByURL(context.Background(), clusterURL)
+	loaded, err := s.repo.FindByURL(context.Background(), clusterURL)
 	// then
 	assert.Nil(s.T(), loaded)
-	test.AssertError(s.T(), err, errors.NotFoundError{}, fmt.Sprintf("cluster with url %s not found", clusterURL))
+	test.AssertError(s.T(), err, errors.NotFoundError{}, fmt.Sprintf("cluster with url '%s' not found", clusterURL))
 }
 
 func (s *clusterRepositoryTestSuite) TestCreateOKInCreateOrSave() {
@@ -76,7 +76,7 @@ func (s *clusterRepositoryTestSuite) TestCreateOKInCreateOrSave() {
 	require.NoError(s.T(), err)
 	test.CreateCluster(s.T(), s.DB) // noise
 	// when
-	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster.URL)
+	loaded, err := s.repo.FindByURL(context.Background(), cluster.URL)
 	// then
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), loaded)
@@ -89,7 +89,7 @@ func (s *clusterRepositoryTestSuite) TestSaveOKInCreateOrSave() {
 	test.CreateCluster(s.T(), s.DB) // noise
 	err := s.repo.CreateOrSave(context.Background(), &cluster)
 	require.NoError(s.T(), err)
-	loaded, err := s.repo.LoadClusterByURL(context.Background(), cluster.URL)
+	loaded, err := s.repo.FindByURL(context.Background(), cluster.URL)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), loaded)
 	test.AssertEqualCluster(s.T(), cluster, *loaded, true)
@@ -110,7 +110,7 @@ func (s *clusterRepositoryTestSuite) TestSaveOKInCreateOrSave() {
 	err = s.repo.CreateOrSave(context.Background(), &cluster)
 	require.NoError(s.T(), err)
 	// when
-	loaded, err = s.repo.LoadClusterByURL(context.Background(), cluster.URL)
+	loaded, err = s.repo.FindByURL(context.Background(), cluster.URL)
 	// then
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), loaded)

--- a/controller/clusters.go
+++ b/controller/clusters.go
@@ -61,7 +61,7 @@ func (c *ClustersController) ListForAuthClient(ctx *app.ListForAuthClientCluster
 	})
 }
 
-// Show returns the single clusters.
+// Show returns a single cluster.
 func (c *ClustersController) Show(ctx *app.ShowClustersContext) error {
 	// authorization is checked at the service level for more consistency accross the codebase.
 	clustr, err := c.app.ClusterService().Load(ctx, ctx.ClusterID)
@@ -83,6 +83,32 @@ func (c *ClustersController) ShowForAuthClient(ctx *app.ShowForAuthClientCluster
 	}
 	return ctx.OK(&app.FullClusterSingle{
 		Data: convertToFullClusterData(*clustr),
+	})
+}
+
+// FindByURL returns a single cluster given its URL.
+// Response does NOT include the sensitive information about the cluster
+func (c *ClustersController) FindByURL(ctx *app.FindByURLClustersContext) error {
+	// authorization is checked at the service level for more consistency accross the codebase.
+	clustr, err := c.app.ClusterService().FindByURL(ctx, ctx.ClusterURL)
+	if err != nil {
+		return app.JSONErrorResponse(ctx, err)
+	}
+	return ctx.OK(&app.ClusterSingle{
+		Data: convertToClusterData(*clustr),
+	})
+}
+
+// FindByURLForAuth returns a single cluster given its URL. Restricted to `auth` SA.
+// Response DOES include the sensitive information about the cluster
+func (c *ClustersController) FindByURLForAuth(ctx *app.FindByURLForAuthClustersContext) error {
+	// authorization is checked at the service level for more consistency accross the codebase.
+	clustr, err := c.app.ClusterService().FindByURLForAuth(ctx, ctx.ClusterURL)
+	if err != nil {
+		return app.JSONErrorResponse(ctx, err)
+	}
+	return ctx.OK(&app.ClusterSingle{
+		Data: convertToClusterData(*clustr),
 	})
 }
 

--- a/design/clusters.go
+++ b/design/clusters.go
@@ -155,6 +155,38 @@ var _ = a.Resource("clusters", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
 
+	a.Action("findByURL", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET("/"),
+		)
+		a.Params(func() {
+			a.Param("cluster_url", d.String, "the URL of the cluster to show")
+			a.Required("cluster_url")
+		})
+		a.Description("Get single cluster configuration given its URL")
+		a.Response(d.OK, showSingleCluster)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+
+	a.Action("findByURLForAuth", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET("/auth"),
+		)
+		a.Params(func() {
+			a.Param("cluster_url", d.String, "the URL of the cluster to show")
+			a.Required("cluster_url")
+		})
+		a.Description("Get single cluster configuration given its URL, with full info")
+		a.Response(d.OK, showSingleCluster)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+
 	a.Action("create", func() {
 		a.Security("jwt")
 		a.Routing(

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -19,15 +19,15 @@ import (
 
 // CreateCluster returns a new cluster after saves it in the DB
 func CreateCluster(t *testing.T, db *gorm.DB) repository.Cluster {
-	cluster := NewCluster()
+	c := NewCluster()
 	repo := repository.NewClusterRepository(db)
-	err := repo.Create(context.Background(), &cluster)
+	err := repo.Create(context.Background(), &c)
 	require.NoError(t, err)
 	// verify that the cluster exists in the DB
-	cls, err := repo.Load(context.Background(), cluster.ClusterID)
+	cls, err := repo.Load(context.Background(), c.ClusterID)
 	require.NoError(t, err)
-	AssertEqualCluster(t, cluster, *cls, true)
-	return cluster
+	AssertEqualCluster(t, c, *cls, true)
+	return c
 }
 
 // NewCluster returns a new cluster with random values for all fields
@@ -194,9 +194,9 @@ func AssertEqualFullClusterData(t *testing.T, expected repository.Cluster, actua
 
 // FilterClusterByURL returns the cluster that has the given URL or an error if none was found
 func FilterClusterByURL(url string, clusters []repository.Cluster) (repository.Cluster, error) {
-	for _, cluster := range clusters {
-		if cluster.URL == url {
-			return cluster, nil
+	for _, c := range clusters {
+		if c.URL == url {
+			return c, nil
 		}
 	}
 	return repository.Cluster{}, errors.Errorf("unable to find cluster with url '%s'", url)


### PR DESCRIPTION
provide 2 endpoints, one for auth which returns
sensitive info, one for service accounts which does
not return the sensitive info (same logic as with the
`List` and `Show` endpoints)

fixes #59

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>