### PR TITLE
Delete clusters from DB when they deleted from config

### DIFF
--- a/cluster/repository/cluster_repository_blackbox_test.go
+++ b/cluster/repository/cluster_repository_blackbox_test.go
@@ -130,6 +130,17 @@ func (s *clusterRepositoryTestSuite) TestSaveOKInCreateOrSave() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), loaded)
 	test.AssertEqualCluster(s.T(), cluster, *loaded, true)
+
+	// now when we reset the capacity exhausted flag it should be updated in DB
+	cluster.CapacityExhausted = false
+	err = s.repo.CreateOrSave(context.Background(), &cluster)
+	require.NoError(s.T(), err)
+	loaded, err = s.repo.FindByURL(context.Background(), cluster.URL)
+	// then check it's updated
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), loaded)
+	test.AssertEqualCluster(s.T(), cluster, *loaded, true)
+	assert.False(s.T(), loaded.CapacityExhausted)
 }
 
 func (s *clusterRepositoryTestSuite) TestDelete() {
@@ -201,6 +212,17 @@ func (s *clusterRepositoryTestSuite) TestSaveOK() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), loaded2)
 	test.AssertEqualCluster(s.T(), cluster2, *loaded2, true)
+
+	// now when we reset the capacity exhausted flag it should be updated in DB
+	cluster1.CapacityExhausted = false
+	err = s.repo.CreateOrSave(context.Background(), &cluster1)
+	require.NoError(s.T(), err)
+	loaded1, err = s.repo.FindByURL(context.Background(), cluster1.URL)
+	// then check it's updated
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), loaded1)
+	test.AssertEqualCluster(s.T(), cluster1, *loaded1, true)
+	assert.False(s.T(), loaded1.CapacityExhausted)
 }
 
 func (s *clusterRepositoryTestSuite) TestSaveUnknownFails() {
@@ -247,7 +269,6 @@ func (s *clusterRepositoryTestSuite) TestList() {
 		clusters, err := s.repo.List(context.Background(), nil)
 		// then
 		require.NoError(t, err)
-		require.Len(t, clusters, 2)
 		test.AssertClusters(t, clusters, cluster1, true)
 		test.AssertClusters(t, clusters, cluster2, true)
 	})

--- a/cluster/service/cluster_service_blackbox_test.go
+++ b/cluster/service/cluster_service_blackbox_test.go
@@ -57,7 +57,17 @@ func (s *ClusterServiceTestSuite) TestCreateOrSaveClusterFromConfigOK() {
 	verifyClusters(s.T(), s.Configuration.GetClusters(), append(osoClusters, osdClusters...), true)
 }
 
-func (s *ClusterServiceTestSuite) TestUpdateFromConfigOK() {
+func (s *ClusterServiceTestSuite) TestMiddleClusterRemovedFromConfig() {
+	// Remove a cluster form the middle
+	s.checkUpdateFromConfigOK("./../../configuration/conf-files/tests/oso-clusters-with-removed-clusters.conf")
+}
+
+func (s *ClusterServiceTestSuite) TestEdgeClustersRemovedFromConfig() {
+	// Remove the first and the last clusters
+	s.checkUpdateFromConfigOK("./../../configuration/conf-files/tests/oso-clusters-with-removed-edge-clusters.conf")
+}
+
+func (s *ClusterServiceTestSuite) checkUpdateFromConfigOK(configFileWithRemovedClusters string) {
 	// given the default configuration
 	ctx, err := createContext(auth.Auth)
 	require.NoError(s.T(), err)
@@ -74,7 +84,7 @@ func (s *ClusterServiceTestSuite) TestUpdateFromConfigOK() {
 	verifyClusters(s.T(), cd.GetClusters(), clusters, true)
 
 	// now given the updated configuration with some clusters deleted
-	cd, err = configuration.NewConfigurationData("", "./../../configuration/conf-files/tests/oso-clusters-with-removed-clusters.conf")
+	cd, err = configuration.NewConfigurationData("", configFileWithRemovedClusters)
 	require.NoError(s.T(), err)
 	db = gormapplication.NewGormDB(s.DB, cd)
 	cs = db.ClusterService()

--- a/configuration/conf-files/tests/oso-clusters-with-removed-clusters.conf
+++ b/configuration/conf-files/tests/oso-clusters-with-removed-clusters.conf
@@ -1,0 +1,41 @@
+{
+    "clusters": [
+        {
+            "name":"us-east-2",
+            "api-url":"https://api.starter-us-east-2.openshift.com",
+            "app-dns":"8a09.starter-us-east-2.openshiftapps.com",
+            "service-account-token":"fX0nH3d68LQ6SK5wBE6QeKJ6X8AZGVQO3dGQZZETakhmgmWAqr2KDFXE65KUwBO69aWoq",
+            "service-account-username":"dsaas",
+            "token-provider-id":"f867ac10-5e05-4359-a0c6-b855ece59090",
+            "auth-client-id":"autheast2",
+            "auth-client-secret":"autheast2secret",
+            "auth-client-default-scope":"user:full"
+        },
+        {
+            "name":"us-east-2a",
+            "api-url":"https://api.starter-us-east-2a.openshift.com",
+            "app-dns":"b542.starter-us-east-2a.openshiftapps.com",
+            "service-account-token":"ak61T6RSAacWFruh1vZP8cyUOBtQ3Chv1rdOBddSuc9nZ2wEcs81DHXRO55NpIpVQ8uiH",
+            "service-account-username":"dsaas",
+            "token-provider-id":"886c7ea3-ef97-443d-b345-de94b94bb65d",
+            "auth-client-id":"autheast2a",
+            "auth-client-secret":"autheast2asecret",
+            "auth-client-default-scope":"user:full",
+            "capacity-exhausted":false
+        },
+        {
+            "name":"us-east-3a",
+            "api-url":"https://api.starter-us-east-3a.openshift.com",
+            "app-dns":"b542.starter-us-east-3a.openshiftapps.com",
+            "service-account-token":"fkdjhfdsjfgfdjlsflhjgsafgskfdsagrwgwerwshbdjasbdjbsahdbsagbdyhsbdesbh",
+            "service-account-username":"dsaas",
+            "service-account-token-encrypted": true,
+            "token-provider-id":"1c09073a-13ad-4add-b0ff-197eaf18fc37",
+            "auth-client-id":"autheast3a",
+            "auth-client-secret":"autheast3asecret",
+            "auth-client-default-scope":"user:full",
+            "type": "OSD",
+            "capacity-exhausted":true
+        }
+    ]
+}

--- a/configuration/conf-files/tests/oso-clusters-with-removed-edge-clusters.conf
+++ b/configuration/conf-files/tests/oso-clusters-with-removed-edge-clusters.conf
@@ -1,0 +1,29 @@
+{
+    "clusters": [
+        {
+            "name":"us-east-2a",
+            "api-url":"https://api.starter-us-east-2a.openshift.com",
+            "app-dns":"b542.starter-us-east-2a.openshiftapps.com",
+            "service-account-token":"ak61T6RSAacWFruh1vZP8cyUOBtQ3Chv1rdOBddSuc9nZ2wEcs81DHXRO55NpIpVQ8uiH",
+            "service-account-username":"dsaas",
+            "token-provider-id":"886c7ea3-ef97-443d-b345-de94b94bb65d",
+            "auth-client-id":"autheast2a",
+            "auth-client-secret":"autheast2asecret",
+            "auth-client-default-scope":"user:full",
+            "capacity-exhausted":false
+        },
+        {
+            "name":"us-east-1a",
+            "api-url":"https://api.starter-us-east-1a.openshift.com",
+            "app-dns":"b542.starter-us-east-1a.openshiftapps.com",
+            "service-account-token":"sdfjdlfjdfkjdlfjd12324434543085djdfjd084508gfdkjdofkjg43854085dlkjdlk",
+            "service-account-username":"dsaas",
+            "service-account-token-encrypted": false,
+            "token-provider-id":"886c7ea3-ef97-443d-b345-de94b94bb65d",
+            "auth-client-id":"autheast1a",
+            "auth-client-secret":"autheast1asecret",
+            "auth-client-default-scope":"user:full",
+            "capacity-exhausted":true
+        }
+    ]
+}

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -110,6 +110,15 @@ func AssertEqualClusters(t *testing.T, expected, actual []repository.Cluster, ex
 	}
 }
 
+// AssertContainsClusters verifies that all the list of `expected` clusters contains the given list of clusters
+func AssertContainsClusters(t *testing.T, expected, contains []repository.Cluster, expectSensitiveInfo bool) {
+	for _, a := range contains {
+		e, err := FilterClusterByURL(a.URL, expected)
+		require.NoError(t, err, "cluster not found")
+		AssertEqualCluster(t, e, a, expectSensitiveInfo)
+	}
+}
+
 // AssertEqualCluster verifies that the `actual` and `expected` clusters are have the same values
 // including sensitive details if `expectSensitiveInfo` is `true`
 func AssertEqualCluster(t *testing.T, expected, actual repository.Cluster, expectSensitiveInfo bool) {


### PR DESCRIPTION
This is part of the fix for https://jira.coreos.com/browse/CRT-332

This PR has the following changes:
- When some cluster is deleted from configuration it also is deleted from DB
- capacity_exhausted flag properly saved in DB when the cluster entry is being updated (it was ignored if set to false)