### PR TITLE
Disable sentry

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -536,11 +536,12 @@
   revision = "b1a2d6e8c8b5fc8f601ead62536f02a8e1b6217d"
 
 [[projects]]
-  digest = "1:9ef12bb93d3105a9137f9983a22ade0750da7f16bf9ce120e705b6d5dfe22057"
+  branch = "master"
+  digest = "1:578046baf093df15df2904bbb0fe06f3f2385bad59987532201007754aa7e1d5"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "478fcf54317e52ab69f40bb4c7a1520288d7f7ea"
+  revision = "d5e6a3e2c0ae16fc7480523ebcb7fd4dd3215489"
 
 [[projects]]
   digest = "1:acb3f0a0920a774a911ef413e773ebe9450a399bc989e090c69d0350627b74a1"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,7 +71,7 @@
   revision = "0eb93fc6cee1e202cb0f3ade92e99a2423b49283"
 
 [[projects]]
-  digest = "1:9ff7368c07f30dc981d33e5e990d9840065260c71c2d5f055bfe465b5d2fdfd8"
+  digest = "1:f5f666c026750f920832255d1485bedb2babe0d3b42361b32b86c7db1e2d8c8e"
   name = "github.com/fabric8-services/fabric8-common"
   packages = [
     "auth",
@@ -93,7 +93,7 @@
     "test/suite",
   ]
   pruneopts = "UT"
-  revision = "f06e14243602e383835a8f8cbf3675e24a738322"
+  revision = "8d814590eab3954d984a04bd3b87ac518cf45462"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -262,6 +262,14 @@
   revision = "v3.0.7"
 
 [[projects]]
+  digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
+
+[[projects]]
   digest = "1:af6e5b1562f6756cf345139f4d825f574de46941fc55870b023302eb36eba9cc"
   name = "github.com/lib/pq"
   packages = [
@@ -419,12 +427,12 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:f8ea8635717622a9ede1bd911161a108cb499b686589335350fcaa80710d6a66"
+  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c078b1e43f58d563c74cebe63c85789e76ddb627"
-  version = "v0.11.2"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
+  version = "v1.4.2"
 
 [[projects]]
   digest = "1:bfa0cf18ae62c9a942863e6e7937777b2d44a3dbd42269ff30d26460eb0b73e3"
@@ -472,7 +480,7 @@
   revision = "651d9d916abc3c3d6a91a12549495caba5edffd2"
 
 [[projects]]
-  digest = "1:5110e3d4f130772fd39e6ce8208ad1955b242ccfcc8ad9d158857250579c82f4"
+  digest = "1:fa35b40a29ee68ab67ffcf3374027fb7f10c87e7ad197e10e058fb934b98f0fa"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -480,8 +488,8 @@
     "suite",
   ]
   pruneopts = "UT"
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "3ebf1ddaeb260c4b1ae502a01c7844fa8c1fa0e9"
+  version = "v1.5.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,11 +64,11 @@ required = [
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  version = "0.11.2"
+  version = "1.3.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.1"
+  version = "1.3.0"
 
 [[constraint]]
   name = "gopkg.in/square/go-jose.v2"
@@ -96,4 +96,4 @@ required = [
 
 [[constraint]]
   name = "github.com/fabric8-services/fabric8-common"
-  revision = "f06e14243602e383835a8f8cbf3675e24a738322"
+  revision = "8d814590eab3954d984a04bd3b87ac518cf45462"

--- a/controller/user.go
+++ b/controller/user.go
@@ -23,7 +23,7 @@ func NewUserController(service *goa.Service, app application.Application) *UserC
 
 // Clusters runs the clusters action - DEPRECATED
 func (c *UserController) Clusters(ctx *app.ClustersUserContext) error {
-	identityID, err := auth.LocateIdentity(ctx)
+	identityID, _, err := auth.LocateIdentity(ctx)
 	if err != nil {
 		return app.JSONErrorResponse(ctx, err)
 	}

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/fabric8-services/fabric8-cluster/controller"
 	"github.com/fabric8-services/fabric8-cluster/gormapplication"
 	"github.com/fabric8-services/fabric8-cluster/migration"
-	"github.com/fabric8-services/fabric8-cluster/sentry"
 	"github.com/fabric8-services/fabric8-common/auth"
 	"github.com/fabric8-services/fabric8-common/goamiddleware"
 	"github.com/fabric8-services/fabric8-common/log"
@@ -87,13 +86,13 @@ func main() {
 	}
 
 	// Initialize sentry client
-	haltSentry, err := sentry.Initialize(config, controller.Commit)
-	if err != nil {
-		log.Panic(nil, map[string]interface{}{
-			"err": err,
-		}, "failed to setup the sentry client")
-	}
-	defer haltSentry()
+	// haltSentry, err := sentry.Initialize(config, controller.Commit)
+	// if err != nil {
+	// 	log.Panic(nil, map[string]interface{}{
+	// 		"err": err,
+	// 	}, "failed to setup the sentry client")
+	// }
+	// defer haltSentry()
 
 	if config.DeveloperModeEnabled() && log.IsDebug() {
 		db = db.Debug()


### PR DESCRIPTION
Our sentry service is moving to another location. Let's disable it for now. We might want to migrate to the new server later.